### PR TITLE
chore(rules): add malware pattern updates 2026-02-09

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,5 +1,29 @@
 # Pattern Updates - February 2026
 
+## 2026-02-09: npx Phantom Package / Registry Fallback Pattern
+
+**Sources:**
+- [Aikido - npx Confusion: Packages That Forgot to Claim Their Own Name](https://www.aikido.dev/blog/npx-confusion-unclaimed-package-names)
+- [The Hacker News - Compromised dYdX npm and PyPI Packages Deliver Wallet Stealers and RAT Malware](https://thehackernews.com/2026/02/compromised-dydx-npm-and-pypi-packages.html)
+
+**Event Summary:** Recent supply-chain reporting highlighted widespread abuse potential when `npx` commands reference package names that were never claimed. In that case, npm registry fallback can fetch and execute attacker-published code.
+
+**New Pattern Added:**
+
+### SUP-002: npx Registry Fallback Execution Without `--no-install`
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.86
+- **Pattern:** Detects `npx <package>` usage that lacks the `--no-install` safeguard on the same command line.
+- **Justification:** Aikido reported large-scale real-world execution volume of phantom `npx` package names, and The Hacker News linked the same abuse class in ongoing package compromise reporting.
+- **Mitigation:** Prefer explicit installs and use `npx --no-install` to prevent implicit registry fallback execution.
+
+**Version:** Rules updated from 2026.02.09.4 to 2026.02.09.5
+
+**Testing:** Added assertions in `tests/test_rules.py`, `tests/test_scan.py`, and showcase coverage in `tests/test_showcase_examples.py`.
+
+---
+
 ## 2026-02-09: GitHub Actions Secrets-Dump Exfil Pattern
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -33,6 +33,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `25_wallet_eval_stealth` | Wallet file targeting + dynamic eval + stealth execution markers | `EXF-002`, `MAL-004`, `OBF-002` |
 | `26_metadata_image_beacon` | Metadata-injected markdown image URL beacon with interpolated exfil placeholder | `EXF-003` |
 | `27_github_actions_secrets_exfil` | GitHub Actions full secrets context expansion with outbound transfer | `EXF-004`, `CHN-004` |
+| `28_npx_registry_fallback` | `npx` command without `--no-install` guard (implicit registry fallback execution risk) | `SUP-002` |
 
 ## Commands
 

--- a/examples/showcase/28_npx_registry_fallback/SKILL.md
+++ b/examples/showcase/28_npx_registry_fallback/SKILL.md
@@ -1,0 +1,9 @@
+# Setup
+
+Run this from a clean repo:
+
+```bash
+npx openapi-generator-cli generate -i spec.yaml -g python
+```
+
+If the package is not already installed locally, this can pull from the registry and execute unclaimed/malicious packages.

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -29,6 +29,7 @@ Each folder demonstrates one major detection or behavior.
 25. `25_wallet_eval_stealth`: wallet-targeting + dynamic eval + stealth execution markers (`EXF-002`, `MAL-004`, `OBF-002`)
 26. `26_metadata_image_beacon`: metadata-injected markdown image beacon with interpolated exfil marker (`EXF-003`)
 27. `27_github_actions_secrets_exfil`: GitHub Actions full-secrets expansion with outbound POST (`EXF-004`, `CHN-004`)
+28. `28_npx_registry_fallback`: npx execution without `--no-install` safeguard (`SUP-002`)
 
 ## Run examples
 
@@ -39,4 +40,5 @@ skillscan scan examples/showcase/09_policy_block_domain --policy examples/polici
 skillscan scan examples/showcase/20_ai_semantic_risk --ai-assist --fail-on never
 skillscan scan examples/showcase/21_npm_lifecycle_abuse --fail-on never
 skillscan scan examples/showcase/27_github_actions_secrets_exfil --fail-on never
+skillscan scan examples/showcase/28_npx_registry_fallback --fail-on never
 ```

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.09.4"
+version: "2026.02.09.5"
 
 static_rules:
   - id: MAL-001
@@ -96,6 +96,14 @@ static_rules:
     title: Stealth execution pattern
     pattern: 'CREATE_NO_WINDOW|nohup.*>/dev/null|&\s*>/dev/null\s*2>&1|\.bat\s+>nul\s+2>&1'
     mitigation: Remove hidden/stealth execution flags and output redirection that obscure command behavior.
+
+  - id: SUP-002
+    category: malware_pattern
+    severity: high
+    confidence: 0.86
+    title: npx registry fallback execution without --no-install
+    pattern: '\bnpx\s+(?![^\n]*--no-install\b)(?:@[a-z0-9._-]+/[a-z0-9._-]+|[a-z0-9._-]+)\b'
+    mitigation: Avoid implicit npx registry fallback. Prefer explicit local installs and use `npx --no-install` for command execution.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -69,3 +69,9 @@ def test_new_patterns_2026_02_09() -> None:
     chn004 = next((r for r in compiled.chain_rules if r.id == "CHN-004"), None)
     assert chn004 is not None
     assert "gh_actions_secrets" in chn004.all_of
+
+    # SUP-002: npx fallback execution without --no-install
+    sup002 = next((r for r in compiled.static_rules if r.id == "SUP-002"), None)
+    assert sup002 is not None
+    assert sup002.pattern.search("npx openapi-generator-cli generate") is not None
+    assert sup002.pattern.search("npx --no-install openapi-generator-cli generate") is None

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -208,6 +208,18 @@ def test_npm_safe_lifecycle_script_not_flagged(tmp_path: Path) -> None:
     assert not any(f.id == "SUP-001" for f in report.findings)
 
 
+def test_npx_registry_fallback_without_no_install_is_flagged(tmp_path: Path) -> None:
+    target = tmp_path / "skill"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(
+        "Run `npx openapi-generator-cli generate -i spec.yaml -g python`.",
+        encoding="utf-8",
+    )
+    policy = load_builtin_policy("strict")
+    report = scan(target, policy, "builtin:strict")
+    assert any(f.id == "SUP-002" for f in report.findings)
+
+
 def test_executable_binary_is_flagged(tmp_path: Path) -> None:
     target = tmp_path / "bundle"
     target.mkdir(parents=True)

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -35,6 +35,7 @@ def test_showcase_detection_rules() -> None:
     findings_27 = _scan("examples/showcase/27_github_actions_secrets_exfil").findings
     assert any(f.id == "EXF-004" for f in findings_27)
     assert any(f.id == "CHN-004" for f in findings_27)
+    assert any(f.id == "SUP-002" for f in _scan("examples/showcase/28_npx_registry_fallback").findings)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add SUP-002 static rule to detect `npx` execution without `--no-install` safeguard (phantom package / registry fallback risk)
- bump default rulepack version to 2026.02.09.5
- add showcase fixture: `examples/showcase/28_npx_registry_fallback`
- update showcase/docs indexes and pattern update notes with source-backed rationale
- add test coverage in `tests/test_rules.py`, `tests/test_scan.py`, and `tests/test_showcase_examples.py`

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests
