### PR TITLE
chore(rules): add malware pattern updates 2026-02-13

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,5 +1,37 @@
 # Pattern Updates - February 2026
 
+## 2026-02-13 (1): pull_request_target Untrusted Head Checkout Pattern
+
+**Sources:**
+- [GitHub Security Advisory - GHSA-h25v-8c87-rvm8 (Secrets exfiltration via `pull_request_target`)](https://github.com/spotipy-dev/spotipy/security/advisories/GHSA-h25v-8c87-rvm8)
+- [NVD - CVE-2025-47928](https://nvd.nist.gov/vuln/detail/CVE-2025-47928)
+
+**Event Summary:** Public advisory and NVD records describe a workflow anti-pattern where `pull_request_target` jobs check out untrusted fork PR head refs (`github.event.pull_request.head.ref` / `head.sha`). This allows attacker-controlled code to run with base-repository token/secrets context.
+
+**New Patterns Added:**
+
+### EXF-005: GitHub Actions untrusted PR head checkout reference
+- **Category:** exfiltration
+- **Severity:** high
+- **Confidence:** 0.91
+- **Pattern:** Detects `ref:` / `repository:` references to `github.event.pull_request.head.*` in workflow content.
+- **Justification:** This is the exploit-enabling checkout marker highlighted by GHSA-h25v-8c87-rvm8 / CVE-2025-47928.
+- **Mitigation:** Do not check out untrusted PR head refs in privileged workflows.
+
+### CHN-005: pull_request_target with untrusted PR head checkout
+- **Category:** exfiltration
+- **Severity:** critical
+- **Confidence:** 0.93
+- **Pattern:** Chains `pull_request_target` event markers with `github.event.pull_request.head.*` checkout markers.
+- **Justification:** Improves precision by requiring both privileged trigger context and untrusted checkout indicators.
+- **Mitigation:** Use unprivileged `pull_request` jobs for untrusted code, and avoid secret-bearing contexts for fork-controlled refs.
+
+**Version:** Rules updated from 2026.02.12.1 to 2026.02.13.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_13`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/34_pr_target_checkout_exfil`.
+
+---
+
 ## 2026-02-12 (1): BYOVD Security-Killer Toolkit Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -38,6 +38,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `31_clickfix_powershell_iex` | PowerShell web request piped to in-memory execution (`iwr/irm` + `iex`) seen in ClickFix-style lures | `MAL-006` |
 | `32_npm_shell_bootstrap` | npm `preinstall`/`postinstall` shell bootstrap commands (`curl`/`wget`/PowerShell) | `SUP-004` |
 | `33_byovd_security_killer` | BYOVD vulnerable-driver service creation + AV/EDR-killer toolkit markers | `MAL-007` |
+| `34_pr_target_checkout_exfil` | `pull_request_target` workflow that checks out untrusted PR head refs (`head.ref`/`head.sha`) | `EXF-005`, `CHN-005` |
 
 ## Commands
 

--- a/examples/showcase/34_pr_target_checkout_exfil/.github/workflows/integration_tests.yml
+++ b/examples/showcase/34_pr_target_checkout_exfil/.github/workflows/integration_tests.yml
@@ -1,0 +1,16 @@
+name: integration-tests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - run: pip install .
+      - run: pytest -q

--- a/examples/showcase/34_pr_target_checkout_exfil/SKILL.md
+++ b/examples/showcase/34_pr_target_checkout_exfil/SKILL.md
@@ -1,0 +1,26 @@
+# CI Workflow Snippet (MALICIOUS)
+
+This sample demonstrates a high-risk GitHub Actions pattern where `pull_request_target` checks out untrusted PR head content.
+
+```yaml
+name: integration-tests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - run: pip install .
+      - run: pytest -q
+```
+
+Expected detection:
+- EXF-005: GitHub Actions untrusted PR head checkout reference
+- CHN-005: pull_request_target with untrusted PR head checkout

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -35,6 +35,7 @@ Each folder demonstrates one major detection or behavior.
 31. `31_clickfix_powershell_iex`: PowerShell web request piped to in-memory execution (`MAL-006`)
 32. `32_npm_shell_bootstrap`: npm preinstall/postinstall shell bootstrap via curl/wget/PowerShell (`SUP-004`)
 33. `33_byovd_security_killer`: BYOVD driver/service markers and AV-killer toolkit references (`MAL-007`)
+34. `34_pr_target_checkout_exfil`: `pull_request_target` workflow checking out untrusted PR head refs (`EXF-005`, `CHN-005`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.12.1"
+version: "2026.02.13.1"
 
 static_rules:
   - id: MAL-001
@@ -64,6 +64,14 @@ static_rules:
     title: GitHub Actions full secrets context dump
     pattern: '\$\{\{\s*toJSON\(\s*secrets\s*\)\s*\}\}'
     mitigation: Never serialize full GitHub Actions secrets context; pass only minimally scoped values required for a specific step.
+
+  - id: EXF-005
+    category: exfiltration
+    severity: high
+    confidence: 0.91
+    title: GitHub Actions untrusted PR head checkout reference
+    pattern: 'ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.(?:sha|ref)\s*\}\}|repository:\s*\$\{\{\s*github\.event\.pull_request\.head\.repo\.full_name\s*\}\}'
+    mitigation: Avoid checking out `github.event.pull_request.head.*` in privileged workflows. Use `pull_request` for untrusted code, or gate privileged jobs and use immutable trusted refs.
 
   - id: MAL-003
     category: malware_pattern
@@ -159,6 +167,8 @@ action_patterns:
   secret_access: '(\.env|id_rsa|aws_access_key_id|ssh key|credentials?)'
   network: 'https?://|webhook|post\b|upload|socket|requests\.'
   gh_actions_secrets: '\$\{\{\s*(?:toJSON\(\s*secrets\s*\)|secrets\.[A-Za-z_][A-Za-z0-9_]*)\s*\}\}'
+  gh_pr_target: '\bpull_request_target\b'
+  gh_pr_head_checkout: '\$\{\{\s*github\.event\.pull_request\.head\.(?:sha|ref|repo\.full_name)\s*\}\}'
   privilege: '\bsudo\b|run as administrator|elevat'
   security_disable: 'disable (security|defender|av|antivirus)|turn off (security|defender|av|antivirus)'
 
@@ -189,6 +199,15 @@ chain_rules:
     all_of: [gh_actions_secrets, network]
     snippet: GitHub Actions secrets context + network/exfil markers detected
     mitigation: Remove full secrets-context expansion and block outbound transfer of CI/CD secrets.
+
+  - id: CHN-005
+    category: exfiltration
+    severity: critical
+    confidence: 0.93
+    title: "pull_request_target with untrusted PR head checkout"
+    all_of: [gh_pr_target, gh_pr_head_checkout]
+    snippet: pull_request_target + github.event.pull_request.head.* checkout markers detected
+    mitigation: Do not combine `pull_request_target` with checkout of untrusted PR head refs. Use unprivileged `pull_request` jobs for untrusted code.
 
   - id: ABU-002
     category: instruction_abuse

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -149,3 +149,24 @@ def test_new_patterns_2026_02_12() -> None:
     assert mal007.pattern.search("poortry driver deployed") is not None
     assert mal007.pattern.search("ghostdriver module") is not None
     assert mal007.pattern.search("driver toolkit") is None
+
+
+def test_new_patterns_2026_02_13() -> None:
+    """Test pull_request_target + untrusted PR-head checkout pattern."""
+    compiled = load_compiled_builtin_rulepack()
+
+    exf005 = next((r for r in compiled.static_rules if r.id == "EXF-005"), None)
+    assert exf005 is not None
+    assert exf005.pattern.search("ref: ${{ github.event.pull_request.head.sha }}") is not None
+    assert (
+        exf005.pattern.search("repository: ${{ github.event.pull_request.head.repo.full_name }}")
+        is not None
+    )
+    assert exf005.pattern.search("ref: refs/heads/main") is None
+
+    assert "gh_pr_target" in compiled.action_patterns
+    assert "gh_pr_head_checkout" in compiled.action_patterns
+    chn005 = next((r for r in compiled.chain_rules if r.id == "CHN-005"), None)
+    assert chn005 is not None
+    assert "gh_pr_target" in chn005.all_of
+    assert "gh_pr_head_checkout" in chn005.all_of

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -40,6 +40,9 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "MAL-006" for f in _scan("examples/showcase/31_clickfix_powershell_iex").findings)
     assert any(f.id == "SUP-004" for f in _scan("examples/showcase/32_npm_shell_bootstrap").findings)
     assert any(f.id == "MAL-007" for f in _scan("examples/showcase/33_byovd_security_killer").findings)
+    findings_34 = _scan("examples/showcase/34_pr_target_checkout_exfil").findings
+    assert any(f.id == "EXF-005" for f in findings_34)
+    assert any(f.id == "CHN-005" for f in findings_34)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
Adds a new high-signal GitHub Actions pattern from recent advisory coverage:
- EXF-005: GitHub Actions untrusted PR head checkout reference
- CHN-005: pull_request_target with untrusted PR head checkout

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests

## Showcase/docs
- Added examples/showcase/34_pr_target_checkout_exfil
- Updated examples/showcase/INDEX.md and docs/EXAMPLES.md
- Documented rationale in PATTERN_UPDATES.md with source links
