### PR TITLE
chore(rules): add malware pattern updates 2026-02-13

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,5 +1,29 @@
 # Pattern Updates - February 2026
 
+## 2026-02-13 (2): Discord Electron Debugger Credential Interception Marker
+
+**Sources:**
+- [JFrog Security Research - How a Complex Multi Payload Infostealer Hid in NPM Disguised as 'Console Visibility'](https://research.jfrog.com/post/duer-js-malicious-package/)
+- [The Hacker News - Lazarus Campaign Plants Malicious Packages in npm and PyPI Ecosystems](https://thehackernews.com/2026/02/lazarus-campaign-plants-malicious.html)
+
+**Event Summary:** Recent npm malware reporting (including `duer-js`) documented Discord Desktop hijacking behavior where attacker code hooks Electron `webContents.debugger`, intercepts auth/MFA-related network events (`/login`, `/register`, `/mfa`, `codes-verification`), and extracts credentials/tokens for exfiltration.
+
+**New Pattern Added:**
+
+### MAL-008: Discord Electron debugger credential interception marker
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.90
+- **Pattern:** Detects `webContents.debugger` interception hooks (`attach`/`on`) and credential/MFA interception markers (`Network.getResponseBody` / `Network.getRequestPostData` with `/login`, `/register`, `/mfa`, `codes-verification`).
+- **Justification:** This is a concrete behavior family in currently active npm infostealer campaigns targeting Discord/Electron clients.
+- **Mitigation:** Remove debugger-based network interception code and any credential/token capture flows.
+
+**Version:** Rules updated from 2026.02.13.1 to 2026.02.13.2
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_13_patch2`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/35_discord_debugger_token_theft`.
+
+---
+
 ## 2026-02-13 (1): pull_request_target Untrusted Head Checkout Pattern
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -39,6 +39,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `32_npm_shell_bootstrap` | npm `preinstall`/`postinstall` shell bootstrap commands (`curl`/`wget`/PowerShell) | `SUP-004` |
 | `33_byovd_security_killer` | BYOVD vulnerable-driver service creation + AV/EDR-killer toolkit markers | `MAL-007` |
 | `34_pr_target_checkout_exfil` | `pull_request_target` workflow that checks out untrusted PR head refs (`head.ref`/`head.sha`) | `EXF-005`, `CHN-005` |
+| `35_discord_debugger_token_theft` | Discord Electron `webContents.debugger` hook intercepting auth/MFA network traffic (`/login`, `/mfa`, `codes-verification`) | `MAL-008` |
 
 ## Commands
 

--- a/examples/showcase/35_discord_debugger_token_theft/SKILL.md
+++ b/examples/showcase/35_discord_debugger_token_theft/SKILL.md
@@ -1,0 +1,15 @@
+# Suspicious Discord helper
+
+This sample demonstrates an Electron debugger hook used to intercept auth responses.
+
+```javascript
+mainWindow["webContents"]["debugger"].attach("1.3");
+mainWindow["webContents"]["debugger"].on("message", async (_evt, method, params) => {
+  if (method !== "Network.responseReceived") return;
+  if (params.response.url.endsWith("/login") || params.response.url.endsWith("/codes-verification")) {
+    await mainWindow["webContents"]["debugger"].sendCommand("Network.getResponseBody", {
+      requestId: params.requestId,
+    });
+  }
+});
+```

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -36,6 +36,7 @@ Each folder demonstrates one major detection or behavior.
 32. `32_npm_shell_bootstrap`: npm preinstall/postinstall shell bootstrap via curl/wget/PowerShell (`SUP-004`)
 33. `33_byovd_security_killer`: BYOVD driver/service markers and AV-killer toolkit references (`MAL-007`)
 34. `34_pr_target_checkout_exfil`: `pull_request_target` workflow checking out untrusted PR head refs (`EXF-005`, `CHN-005`)
+35. `35_discord_debugger_token_theft`: Discord Electron debugger network interception markers used for credential/token theft (`MAL-008`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.13.1"
+version: "2026.02.13.2"
 
 static_rules:
   - id: MAL-001
@@ -160,6 +160,14 @@ static_rules:
     title: BYOVD security-killer toolkit marker
     pattern: '(?i)\b(?:nseckrnl|truesightkiller|aukill|poortry|ghostdriver|warp\s*avkiller)\b|\bsc\s+create\s+(?:nseckrnl|truesightkiller|aukill|poortry|ghostdriver)\b'
     mitigation: Remove BYOVD-related tool/driver references and service-creation commands. Never include guidance that disables EDR/AV through vulnerable drivers.
+
+  - id: MAL-008
+    category: malware_pattern
+    severity: high
+    confidence: 0.9
+    title: Discord Electron debugger credential interception marker
+    pattern: '(?is)(?:webContents[\s\S]{0,80}debugger[\s\S]{0,120}(?:attach|on|sendCommand)[\s\S]{0,900}(?:Network\.(?:getResponseBody|getRequestPostData)|/login|/register|/mfa(?:/totp)?|codes-verification)|Network\.(?:getResponseBody|getRequestPostData)[\s\S]{0,240}(?:/login|/register|/mfa(?:/totp)?|codes-verification))'
+    mitigation: Remove Electron debugger network-interception hooks that capture credentials, MFA data, or tokens from Discord endpoints.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -170,3 +170,24 @@ def test_new_patterns_2026_02_13() -> None:
     assert chn005 is not None
     assert "gh_pr_target" in chn005.all_of
     assert "gh_pr_head_checkout" in chn005.all_of
+
+
+def test_new_patterns_2026_02_13_patch2() -> None:
+    """Test Discord Electron debugger credential interception markers."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal008 = next((r for r in compiled.static_rules if r.id == "MAL-008"), None)
+    assert mal008 is not None
+    assert (
+        mal008.pattern.search(
+            'mainWindow["webContents"]["debugger"].attach("1.3"); Network.getResponseBody /login'
+        )
+        is not None
+    )
+    assert (
+        mal008.pattern.search(
+            "Network.getRequestPostData ... /mfa/totp"
+        )
+        is not None
+    )
+    assert mal008.pattern.search('mainWindow.webContents.send("ok")') is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -43,6 +43,7 @@ def test_showcase_detection_rules() -> None:
     findings_34 = _scan("examples/showcase/34_pr_target_checkout_exfil").findings
     assert any(f.id == "EXF-005" for f in findings_34)
     assert any(f.id == "CHN-005" for f in findings_34)
+    assert any(f.id == "MAL-008" for f in _scan("examples/showcase/35_discord_debugger_token_theft").findings)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- Add MAL-008 Discord Electron debugger credential interception marker
- Add showcase fixture 35 for Discord debugger token theft behavior
- Update tests and docs/index entries for new rule coverage
- Record source-backed update notes in PATTERN_UPDATES.md

## Validation
- make setup
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests

## Sources
- https://research.jfrog.com/post/duer-js-malicious-package/
- https://thehackernews.com/2026/02/lazarus-campaign-plants-malicious.html