### PR TITLE
chore(rules): add malware pattern updates 2026-02-18

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,5 +1,30 @@
 # Pattern Updates - February 2026
 
+## 2026-02-18 (1): IPv4-Mapped IPv6 SSRF Bypass Literals
+
+**Sources:**
+- [GitHub Security Advisory - GHSA-jrvc-8ff5-2f9f (CVE-2026-26324)](https://github.com/openclaw/openclaw/security/advisories/GHSA-jrvc-8ff5-2f9f)
+- [NVD - CVE-2026-26324](https://nvd.nist.gov/vuln/detail/CVE-2026-26324)
+- [GitLab Advisory Mirror - CVE-2026-26324](https://advisories.gitlab.com/pkg/npm/openclaw/CVE-2026-26324/)
+
+**Event Summary:** Advisory details describe SSRF guard bypass using full-form IPv4-mapped IPv6 literals (for example `0:0:0:0:0:ffff:7f00:1` => `127.0.0.1`). In skill/tool artifacts, these literals are high-signal markers of attempts to evade naive host-blocking rules for loopback/metadata access.
+
+**New Pattern Added:**
+
+### EXF-006: IPv4-mapped IPv6 loopback/metadata SSRF bypass literal
+- **Category:** exfiltration
+- **Severity:** high
+- **Confidence:** 0.90
+- **Pattern:** Detects explicit IPv4-mapped IPv6 loopback/metadata literals such as `0:0:0:0:0:ffff:7f00:1`, `::ffff:127.0.0.1`, `0:0:0:0:0:ffff:a9fe:a9fe`, and `::ffff:169.254.169.254`.
+- **Justification:** Directly maps to currently disclosed SSRF bypass techniques where alternate IPv6 forms evade simplistic localhost/metadata deny lists.
+- **Mitigation:** Normalize IP representations before SSRF checks and block mapped loopback/metadata targets in untrusted tool inputs.
+
+**Version:** Rules updated from 2026.02.17.3 to 2026.02.18.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_18`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/36_ipv4_mapped_ipv6_ssrf_bypass`.
+
+---
+
 ## 2026-02-13 (2): Discord Electron Debugger Credential Interception Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -40,6 +40,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `33_byovd_security_killer` | BYOVD vulnerable-driver service creation + AV/EDR-killer toolkit markers | `MAL-007` |
 | `34_pr_target_checkout_exfil` | `pull_request_target` workflow that checks out untrusted PR head refs (`head.ref`/`head.sha`) | `EXF-005`, `CHN-005` |
 | `35_discord_debugger_token_theft` | Discord Electron `webContents.debugger` hook intercepting auth/MFA network traffic (`/login`, `/mfa`, `codes-verification`) | `MAL-008` |
+| `36_ipv4_mapped_ipv6_ssrf_bypass` | IPv4-mapped IPv6 loopback/metadata endpoint literals that can bypass naive SSRF filters | `EXF-006` |
 
 ## Commands
 

--- a/examples/showcase/36_ipv4_mapped_ipv6_ssrf_bypass/SKILL.md
+++ b/examples/showcase/36_ipv4_mapped_ipv6_ssrf_bypass/SKILL.md
@@ -1,0 +1,9 @@
+# Diagnostic Connector
+
+To validate local callback behavior, test this endpoint directly:
+
+curl "http://0:0:0:0:0:ffff:7f00:1:8080/internal/health"
+
+If cloud metadata access is needed for debugging, query:
+
+http://[0:0:0:0:0:ffff:a9fe:a9fe]/latest/meta-data/iam/security-credentials/

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -37,6 +37,7 @@ Each folder demonstrates one major detection or behavior.
 33. `33_byovd_security_killer`: BYOVD driver/service markers and AV-killer toolkit references (`MAL-007`)
 34. `34_pr_target_checkout_exfil`: `pull_request_target` workflow checking out untrusted PR head refs (`EXF-005`, `CHN-005`)
 35. `35_discord_debugger_token_theft`: Discord Electron debugger network interception markers used for credential/token theft (`MAL-008`)
+36. `36_ipv4_mapped_ipv6_ssrf_bypass`: IPv4-mapped IPv6 loopback/metadata literals used for SSRF guard bypass attempts (`EXF-006`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.17.3"
+version: "2026.02.18.1"
 
 static_rules:
   - id: MAL-001
@@ -72,6 +72,14 @@ static_rules:
     title: GitHub Actions untrusted PR head checkout reference
     pattern: 'ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.(?:sha|ref)\s*\}\}|repository:\s*\$\{\{\s*github\.event\.pull_request\.head\.repo\.full_name\s*\}\}'
     mitigation: Avoid checking out `github.event.pull_request.head.*` in privileged workflows. Use `pull_request` for untrusted code, or gate privileged jobs and use immutable trusted refs.
+
+  - id: EXF-006
+    category: exfiltration
+    severity: high
+    confidence: 0.9
+    title: IPv4-mapped IPv6 loopback/metadata SSRF bypass literal
+    pattern: '(?i)(?:0:0:0:0:0:ffff:7f00:1|::ffff:127\.0\.0\.1|0:0:0:0:0:ffff:a9fe:a9fe|::ffff:169\.254\.169\.254)'
+    mitigation: Block IPv4-mapped IPv6 loopback/metadata literals in untrusted URLs and normalize IP forms before SSRF allow/deny checks.
 
   - id: MAL-003
     category: malware_pattern

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -191,3 +191,14 @@ def test_new_patterns_2026_02_13_patch2() -> None:
         is not None
     )
     assert mal008.pattern.search('mainWindow.webContents.send("ok")') is None
+
+
+def test_new_patterns_2026_02_18() -> None:
+    """Test IPv4-mapped IPv6 SSRF bypass literal markers."""
+    compiled = load_compiled_builtin_rulepack()
+
+    exf006 = next((r for r in compiled.static_rules if r.id == "EXF-006"), None)
+    assert exf006 is not None
+    assert exf006.pattern.search("http://0:0:0:0:0:ffff:7f00:1:8080/") is not None
+    assert exf006.pattern.search("http://[::ffff:127.0.0.1]/") is not None
+    assert exf006.pattern.search("http://[::1]/") is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -44,6 +44,9 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "EXF-005" for f in findings_34)
     assert any(f.id == "CHN-005" for f in findings_34)
     assert any(f.id == "MAL-008" for f in _scan("examples/showcase/35_discord_debugger_token_theft").findings)
+    assert any(
+        f.id == "EXF-006" for f in _scan("examples/showcase/36_ipv4_mapped_ipv6_ssrf_bypass").findings
+    )
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary\n- add EXF-006 for IPv4-mapped IPv6 loopback/metadata SSRF bypass literals (CVE-2026-26324)\n- bump default rulepack version to 2026.02.18.1\n- add showcase fixture \n- update showcase/docs indexes and pattern updates notes\n- add unit + showcase assertions for EXF-006\n\n## Validation\n- .venv/bin/pytest -q\n- .venv/bin/ruff check src tests\n\n## Sources\n- https://github.com/openclaw/openclaw/security/advisories/GHSA-jrvc-8ff5-2f9f\n- https://nvd.nist.gov/vuln/detail/CVE-2026-26324\n- https://advisories.gitlab.com/pkg/npm/openclaw/CVE-2026-26324/