### PR TITLE
chore(rules): add malware pattern updates 2026-02-20

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,27 @@
+## 2026-02-20 (2): Dotenv Newline Environment-Variable Injection Payload Marker
+
+**Sources:**
+- [GitHub Advisory Database - CVE-2026-27203 (GHSA-97rm-xj73-33jh)](https://github.com/advisories/GHSA-97rm-xj73-33jh)
+- [GitLab Advisory Mirror - CVE-2026-27203](https://advisories.gitlab.com/pkg/npm/ebay-mcp/CVE-2026-27203/)
+
+**Event Summary:** A newly published MCP advisory (Feb 18-19, 2026) describes a token update tool writing user-controlled values into `.env` without rejecting newline/carriage-return characters. Attackers can smuggle additional key/value pairs (for example `NODE_OPTIONS=...`) and poison runtime configuration.
+
+**New Pattern Added:**
+
+### SUP-006: Dotenv newline environment-variable injection payload marker
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.89
+- **Pattern:** Detects token/update input strings where token-like fields contain newline encodings (`\n`, `\r`, `%0a`, `%0d`) followed by injected uppercase env assignments.
+- **Justification:** Captures the concrete payload shape used to exploit unsafe `.env` update helpers in MCP token management flows.
+- **Mitigation:** Reject CR/LF in token inputs, enforce strict key allowlists, and serialize `.env` updates safely.
+
+**Version:** Rules updated from 2026.02.20.1 to 2026.02.20.2
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_20_patch2`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/41_env_newline_injection`.
+
+---
+
 ## 2026-02-20 (1): ClickFix DNS nslookup Staged Execution Pattern
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -45,6 +45,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `38_openclaw_config_token_access` | Access to `.openclaw/openclaw.json` or `device.json` and fields like `gateway.auth.token` / `privateKeyPem` tied to AI-agent identity theft | `EXF-007` |
 | `39_pr_target_metadata_injection` | `pull_request_target` workflow that interpolates untrusted PR metadata (for example `github.event.pull_request.title`) in shell/script steps, enabling command injection in privileged CI contexts | `EXF-008`, `CHN-006` |
 | `40_clickfix_dns_nslookup` | ClickFix variant that parses DNS `nslookup -q=txt` response fields and executes returned command text (`cmd /c`, `powershell`, `iex`) | `MAL-009` |
+| `41_env_newline_injection` | Newline (`\n`/`%0a`) token payload that injects arbitrary env vars into `.env` update flows (for example `NODE_OPTIONS=...`) | `SUP-006` |
 
 ## Commands
 

--- a/examples/showcase/41_env_newline_injection/SKILL.md
+++ b/examples/showcase/41_env_newline_injection/SKILL.md
@@ -1,0 +1,13 @@
+# OAuth Token Sync Helper (Unsafe Example)
+
+This sample demonstrates a vulnerable token update flow where user-provided token text is written into `.env`.
+
+```json
+{
+  "tool": "ebay_set_user_tokens",
+  "accessToken": "ok-token\nNODE_OPTIONS=--require /tmp/evil.js",
+  "refreshToken": "refresh-ok"
+}
+```
+
+Any workflow that accepts newline characters in token fields can inject arbitrary environment variables.

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -42,6 +42,7 @@ Each folder demonstrates one major detection or behavior.
 38. `38_openclaw_config_token_access`: OpenClaw config/token/private-key access markers (`EXF-007`)
 39. `39_pr_target_metadata_injection`: `pull_request_target` workflow interpolating untrusted PR metadata (`title/body`) into shell/script context (`EXF-008`, `CHN-006`)
 40. `40_clickfix_dns_nslookup`: ClickFix DNS-staged execution via `nslookup -q=txt` output parsing and command execution (`MAL-009`)
+41. `41_env_newline_injection`: dotenv newline env-var injection payload in token update input (`SUP-006`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.20.1"
+version: "2026.02.20.2"
 
 static_rules:
   - id: MAL-001
@@ -208,6 +208,15 @@ static_rules:
     title: ClickFix DNS nslookup staged command execution pattern
     pattern: '(?i)\bnslookup(?:\.exe)?\b[^\n]{0,260}(?:\s+-q=txt|\s+-querytype=txt)\b[^\n]{0,260}\b(?:findstr|for\s+/f|select-string)\b[^\n]{0,260}\b(?:cmd(?:\.exe)?\s*/c|powershell(?:\.exe)?|pwsh|iex|invoke-expression)\b'
     mitigation: Do not include ClickFix-style instructions that parse DNS lookup output and execute it. Never run clipboard/Run-dialog commands from untrusted pages.
+
+
+  - id: SUP-006
+    category: malware_pattern
+    severity: high
+    confidence: 0.89
+    title: Dotenv newline environment-variable injection payload marker
+    pattern: '(?i)(?:access[_-]?token|refresh[_-]?token|client[_-]?secret|set[_-]?user[_-]?tokens)[^\n]{0,180}(?:%0a|%0d|\\n|\\r)[^\n]{0,120}[A-Z][A-Z0-9_]{2,}\s*='
+    mitigation: Reject newline/carriage-return characters in token inputs before writing `.env` files. Update env values via strict key allowlists and escaped serialization.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -269,3 +269,29 @@ def test_new_patterns_2026_02_20() -> None:
         is not None
     )
     assert mal009.pattern.search('nslookup example.com 8.8.8.8') is None
+
+
+def test_new_patterns_2026_02_20_patch2() -> None:
+    """Test dotenv newline environment-variable injection payload markers."""
+    compiled = load_compiled_builtin_rulepack()
+
+    sup006 = next((r for r in compiled.static_rules if r.id == "SUP-006"), None)
+    assert sup006 is not None
+    assert (
+        sup006.pattern.search(
+            'tool_input={"accessToken":"abc\\nNODE_OPTIONS=--require /tmp/pwn.js"}'
+        )
+        is not None
+    )
+    assert (
+        sup006.pattern.search(
+            'ebay_set_user_tokens refreshToken=ok%0aEBAY_REDIRECT_URI=https://attacker.example/cb'
+        )
+        is not None
+    )
+    assert (
+        sup006.pattern.search(
+            'ebay_set_user_tokens accessToken=plain-token-without-newline'
+        )
+        is None
+    )

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -53,6 +53,7 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "EXF-008" for f in findings_39)
     assert any(f.id == "CHN-006" for f in findings_39)
     assert any(f.id == "MAL-009" for f in _scan("examples/showcase/40_clickfix_dns_nslookup").findings)
+    assert any(f.id == "SUP-006" for f in _scan("examples/showcase/41_env_newline_injection").findings)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary\n- add SUP-006 pattern for dotenv newline env-var injection payloads in token update flows\n- bump default rules version to 2026.02.20.2\n- add tests and showcase fixture (41_env_newline_injection)\n- document rationale and sources in PATTERN_UPDATES.md\n\n## Validation\n- .venv/bin/pytest -q\n- .venv/bin/ruff check src tests