### PR TITLE
chore(rules): add malware pattern updates 2026-02-23

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,28 @@
+## 2026-02-23 (1): npm Lifecycle Mutable `@latest` Install in Install Hooks
+
+**Sources:**
+- [Cline Security Advisory - GHSA-9ppg-jx86-fqw7](https://github.com/cline/cline/security/advisories/GHSA-9ppg-jx86-fqw7)
+- [GitHub Advisory Database - GHSA-9ppg-jx86-fqw7](https://github.com/advisories/GHSA-9ppg-jx86-fqw7)
+- [Socket - Cline CLI npm package compromised via suspected cache poisoning](https://socket.dev/blog/cline-cli-npm-package-compromised-via-suspected-cache-poisoning-attack)
+
+**Event Summary:** The Feb 17 compromise of `cline@2.3.0` used a `postinstall` hook to pull `openclaw@latest`. SkillScan already flagged global installs in lifecycle hooks (`SUP-007`), but this incident highlights a reusable evasion variant: install-hook dependency pulls pinned to mutable `@latest` tags without `-g`, which still allow attacker-controlled code changes during install.
+
+**New Pattern Added:**
+
+### SUP-008: npm lifecycle mutable @latest dependency install pattern
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.84
+- **Pattern:** Detects `package.json` `preinstall`/`postinstall` scripts that run `npm install`/`npm i` with an `@latest` package selector (non-global install hooks).
+- **Justification:** Captures mutable-tag dependency execution in lifecycle hooks, a concrete install-time supply-chain risk adjacent to GHSA-9ppg-jx86-fqw7 and not covered by existing global-only hook rule.
+- **Mitigation:** Disallow `@latest` in install lifecycle hooks; pin exact versions and move dependency setup to explicit, reviewed, user-triggered steps.
+
+**Version:** Rules updated from 2026.02.21.2 to 2026.02.23.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_23`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/44_npm_lifecycle_latest_install`.
+
+---
+
 ## 2026-02-21 (2): GitHub Actions Issue/Comment Metadata Interpolation in Shell Context
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -48,6 +48,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `41_env_newline_injection` | Newline (`\n`/`%0a`) token payload that injects arbitrary env vars into `.env` update flows (for example `NODE_OPTIONS=...`) | `SUP-006` |
 | `42_npm_lifecycle_global_install` | npm `preinstall`/`postinstall` lifecycle script performs global package install (`npm install -g` / `npm i -g`) | `SUP-007` |
 | `43_gh_issue_metadata_injection` | GitHub Actions `issues`/`issue_comment` workflow interpolates untrusted `${{ github.event.issue.* }}` or `${{ github.event.comment.body }}` directly into shell/script context | `MAL-010` |
+| `44_npm_lifecycle_latest_install` | npm `preinstall`/`postinstall` lifecycle script installs mutable `@latest` package version (non-global) during install hooks | `SUP-008` |
 
 ## Commands
 

--- a/examples/showcase/44_npm_lifecycle_latest_install/package.json
+++ b/examples/showcase/44_npm_lifecycle_latest_install/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "showcase-lifecycle-latest-install",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm install openclaw@latest --no-audit"
+  }
+}

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -45,6 +45,7 @@ Each folder demonstrates one major detection or behavior.
 41. `41_env_newline_injection`: dotenv newline env-var injection payload in token update input (`SUP-006`)
 42. `42_npm_lifecycle_global_install`: npm lifecycle script performing global package install (`npm install -g` / `npm i -g`) from install hooks (`SUP-007`)
 43. `43_gh_issue_metadata_injection`: untrusted issue/comment metadata interpolation in shell/script workflow steps (command-injection risk, `MAL-010`)
+44. `44_npm_lifecycle_latest_install`: npm lifecycle script with mutable `@latest` package install in install hooks (`SUP-008`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.21.2"
+version: "2026.02.23.1"
 
 static_rules:
   - id: MAL-001
@@ -233,6 +233,14 @@ static_rules:
     title: npm preinstall/postinstall global package install pattern
     pattern: '(?i)"(?:preinstall|postinstall)"\s*:\s*"[^"\n]{0,260}\bnpm\s+(?:install|i)\s+-g\s+[^"\n]+'
     mitigation: Remove global package installation from npm install lifecycle hooks. Keep dependency setup explicit, pinned, and user-initiated outside preinstall/postinstall.
+
+  - id: SUP-008
+    category: malware_pattern
+    severity: high
+    confidence: 0.84
+    title: npm lifecycle mutable @latest dependency install pattern
+    pattern: '(?i)"(?:preinstall|postinstall)"\s*:\s*"[^"\n]{0,300}\bnpm\s+(?:install|i)\b(?![^"\n]*(?:\s-g\b|\s--global\b))[^"\n]*@[^\s"\n]*latest\b[^"\n]*"'
+    mitigation: Avoid `npm install ...@latest` inside install lifecycle hooks. Use pinned versions and explicit user-initiated install/update steps outside preinstall/postinstall.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -343,3 +343,35 @@ def test_new_patterns_2026_02_21_patch2() -> None:
         is not None
     )
     assert mal010.pattern.search("run: echo safe") is None
+
+
+def test_new_patterns_2026_02_23() -> None:
+    """Test npm lifecycle mutable @latest dependency install marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    sup008 = next((r for r in compiled.static_rules if r.id == "SUP-008"), None)
+    assert sup008 is not None
+    assert (
+        sup008.pattern.search(
+            '"postinstall": "npm install openclaw@latest"'
+        )
+        is not None
+    )
+    assert (
+        sup008.pattern.search(
+            '"preinstall": "npm i @scope/agent-helper@latest --no-audit"'
+        )
+        is not None
+    )
+    assert (
+        sup008.pattern.search(
+            '"postinstall": "npm install -g openclaw@latest"'
+        )
+        is None
+    )
+    assert (
+        sup008.pattern.search(
+            '"postinstall": "npm install openclaw@2.3.1"'
+        )
+        is None
+    )

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -56,6 +56,7 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "SUP-006" for f in _scan("examples/showcase/41_env_newline_injection").findings)
     assert any(f.id == "SUP-007" for f in _scan("examples/showcase/42_npm_lifecycle_global_install").findings)
     assert any(f.id == "MAL-010" for f in _scan("examples/showcase/43_gh_issue_metadata_injection").findings)
+    assert any(f.id == "SUP-008" for f in _scan("examples/showcase/44_npm_lifecycle_latest_install").findings)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add SUP-008 static rule for npm preinstall/postinstall hooks that install mutable `@latest` dependencies (non-global installs)
- bump rulepack version to `2026.02.23.1`
- add showcase fixture `examples/showcase/44_npm_lifecycle_latest_install`
- update showcase/docs indexes and pattern update notes
- add rule and showcase tests for SUP-008

## Validation
- `.venv/bin/pytest -q` ✅ (100 passed)
- `.venv/bin/ruff check src tests` ✅

## Sources
- https://github.com/cline/cline/security/advisories/GHSA-9ppg-jx86-fqw7
- https://github.com/advisories/GHSA-9ppg-jx86-fqw7
- https://socket.dev/blog/cline-cli-npm-package-compromised-via-suspected-cache-poisoning-attack
