### PR TITLE
chore(rules): add malware pattern updates 2026-02-25

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,36 @@
+## 2026-02-25 (1): pull_request_target Unpinned Third-Party Action Ref Marker
+
+**Sources:**
+- [The Hacker News - Cline CLI 2.3.0 Supply Chain Attack Installed OpenClaw on Developer Systems](https://thehackernews.com/2026/02/cline-cli-230-supply-chain-attack.html)
+- [GitHub Advisory Database - tj-actions/changed-files through 45.0.7 allows remote attackers to discover secrets by reading actions logs (GHSA-mrrh-fwg8-r2c3)](https://github.com/advisories/ghsa-mrrh-fwg8-r2c3)
+- [Unit 42 - GitHub Actions Supply Chain Attack: Coinbase targeting and tj-actions compromise](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)
+
+**Event Summary:** Recent CI/CD incident reporting continues to show attacker success after compromising mutable GitHub Action refs (retargeted tags/branches) in privileged workflows. Existing SkillScan rules covered untrusted checkout refs, metadata interpolation, and cache-key poisoning in `pull_request_target`, but not mutable third-party `uses:` refs in the same privileged context.
+
+**New Patterns Added:**
+
+### MAL-011: pull_request_target workflow using unpinned third-party action ref
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.84
+- **Pattern:** Detects `uses: owner/action@...` references not pinned to a full 40-character commit SHA.
+- **Justification:** Mutable refs (`@v4`, `@main`) can be retargeted during or after upstream compromise, creating a reusable supply-chain execution primitive in privileged workflows.
+- **Mitigation:** Pin third-party actions to immutable full commit SHAs and review provenance before updates.
+
+### CHN-008: pull_request_target with unpinned third-party GitHub Action
+- **Category:** malware_pattern
+- **Severity:** critical
+- **Confidence:** 0.88
+- **Pattern:** Chains `pull_request_target` with mutable third-party `uses:` references.
+- **Justification:** Tightens signal to privileged CI workflows where tag-retarget abuse is high impact.
+- **Mitigation:** Avoid mutable action refs in privileged workflows; use SHA pinning and controlled update cadence.
+
+**Version:** Rules updated from 2026.02.24.1 to 2026.02.25.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_25`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/47_pr_target_unpinned_action`.
+
+---
+
 ## 2026-02-24 (1): pull_request_target Cache-Key Poisoning Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -51,6 +51,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `44_npm_lifecycle_latest_install` | npm `preinstall`/`postinstall` lifecycle script installs mutable `@latest` package version (non-global) during install hooks | `SUP-008` |
 | `45_mcp_tool_prompt_injection` | MCP tool description embeds hidden credential file collection plus “do not mention” context exfiltration instructions | `EXF-009` |
 | `46_pr_target_cache_key_poisoning` | `pull_request_target` workflow derives `actions/cache` key from untrusted PR metadata, enabling cache-poisoning pivot risk in privileged CI context | `EXF-010`, `CHN-007` |
+| `47_pr_target_unpinned_action` | `pull_request_target` workflow uses third-party GitHub Actions pinned to mutable tags/branches (for example `@v4`, `@main`) instead of immutable full SHAs, increasing tag-retarget supply-chain risk | `MAL-011`, `CHN-008` |
 
 ## Commands
 

--- a/examples/showcase/47_pr_target_unpinned_action/SKILL.md
+++ b/examples/showcase/47_pr_target_unpinned_action/SKILL.md
@@ -1,0 +1,19 @@
+# CI triage workflow (intentionally unsafe showcase)
+
+```yaml
+name: triage
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@main
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "triage done"
+```

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -48,6 +48,7 @@ Each folder demonstrates one major detection or behavior.
 44. `44_npm_lifecycle_latest_install`: npm lifecycle script with mutable `@latest` package install in install hooks (`SUP-008`)
 45. `45_mcp_tool_prompt_injection`: MCP tool description with hidden credential-harvest instructions and silent context exfiltration wording (`EXF-009`)
 46. `46_pr_target_cache_key_poisoning`: `pull_request_target` workflow deriving `actions/cache` key from untrusted PR metadata (`EXF-010`, `CHN-007`)
+47. `47_pr_target_unpinned_action`: `pull_request_target` workflow using mutable third-party action refs (tag/branch instead of full SHA) (`MAL-011`, `CHN-008`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.24.1"
+version: "2026.02.25.1"
 
 static_rules:
   - id: MAL-001
@@ -259,6 +259,14 @@ static_rules:
     pattern: '(?i)\bkey:\s*[^\n]*\$\{\{\s*github\.event\.pull_request\.(?:title|body|head\.label|head\.ref|user\.login)\s*\}\}'
     mitigation: Do not derive cache keys from untrusted PR metadata. Use trusted immutable inputs and segregate cache scopes between untrusted and privileged workflows.
 
+  - id: MAL-011
+    category: malware_pattern
+    severity: high
+    confidence: 0.84
+    title: pull_request_target workflow using unpinned third-party action ref
+    pattern: "(?im)^\\s*-?\\s*uses:\\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@(?![0-9a-f]{40}\\b)[^\\s#]+"
+    mitigation: In privileged workflows (especially pull_request_target), pin third-party actions to immutable full commit SHAs instead of mutable tags (v1, v4, main) to prevent tag-retarget supply-chain abuse.
+
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'
   execute: '\b(bash|sh|powershell|pwsh|cmd\.exe|os\.system|subprocess|python\s+-c|python3?\s+[^\s-]\S*|node\s+-e|perl\s+-e|ruby\s+-e)\b'
@@ -269,6 +277,7 @@ action_patterns:
   gh_pr_head_checkout: '\$\{\{\s*github\.event\.pull_request\.head\.(?:sha|ref|repo\.full_name)\s*\}\}'
   gh_pr_untrusted_meta: '\$\{\{\s*github\.event\.pull_request\.(?:title|body|head\.label|user\.login)\s*\}\}'
   gh_cache_untrusted_key: '(?i)\bkey:\s*[^\n]*\$\{\{\s*github\.event\.pull_request\.(?:title|body|head\.label|head\.ref|user\.login)\s*\}\}'
+  gh_unpinned_action_ref: '(?im)^\s*-?\s*uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@(?![0-9a-f]{40}\b)[^\s#]+'
   privilege: '\bsudo\b|run as administrator|elevat'
   security_disable: 'disable (security|defender|av|antivirus)|turn off (security|defender|av|antivirus)'
 
@@ -336,6 +345,15 @@ chain_rules:
     all_of: [gh_pr_target, gh_cache_untrusted_key]
     snippet: pull_request_target + actions/cache key derived from github.event.pull_request.* metadata detected
     mitigation: Avoid cache key derivation from untrusted PR metadata in privileged workflows. Separate caches for untrusted jobs and trusted release/publish jobs.
+
+  - id: CHN-008
+    category: malware_pattern
+    severity: critical
+    confidence: 0.88
+    title: "pull_request_target with unpinned third-party GitHub Action"
+    all_of: [gh_pr_target, gh_unpinned_action_ref]
+    snippet: pull_request_target + third-party action reference pinned to mutable tag/branch detected
+    mitigation: In pull_request_target workflows, pin third-party actions to full 40-char commit SHAs and review upstream provenance before updates.
 
 capability_patterns:
   shell_execution: '\b(subprocess|os\.system|bash|powershell)\b'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -418,3 +418,25 @@ def test_new_patterns_2026_02_24() -> None:
     assert chn007 is not None
     assert "gh_pr_target" in chn007.all_of
     assert "gh_cache_untrusted_key" in chn007.all_of
+
+
+def test_new_patterns_2026_02_25() -> None:
+    """Test pull_request_target unpinned third-party action marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal011 = next((r for r in compiled.static_rules if r.id == "MAL-011"), None)
+    assert mal011 is not None
+    assert mal011.pattern.search("uses: actions/checkout@v4") is not None
+    assert mal011.pattern.search("uses: docker/login-action@main") is not None
+    assert (
+        mal011.pattern.search(
+            "uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608"
+        )
+        is None
+    )
+
+    assert "gh_unpinned_action_ref" in compiled.action_patterns
+    chn008 = next((r for r in compiled.chain_rules if r.id == "CHN-008"), None)
+    assert chn008 is not None
+    assert "gh_pr_target" in chn008.all_of
+    assert "gh_unpinned_action_ref" in chn008.all_of

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -61,6 +61,9 @@ def test_showcase_detection_rules() -> None:
     findings_46 = _scan("examples/showcase/46_pr_target_cache_key_poisoning").findings
     assert any(f.id == "EXF-010" for f in findings_46)
     assert any(f.id == "CHN-007" for f in findings_46)
+    findings_47 = _scan("examples/showcase/47_pr_target_unpinned_action").findings
+    assert any(f.id == "MAL-011" for f in findings_47)
+    assert any(f.id == "CHN-008" for f in findings_47)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add MAL-011 static rule for unpinned third-party uses refs in GitHub Actions
- add CHN-008 chain rule for pull_request_target + unpinned action refs
- bump rules version to 2026.02.25.1
- add showcase fixture examples/showcase/47_pr_target_unpinned_action
- update tests and docs/changelog notes

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests

## Sources
- The Hacker News Cline 2.3.0 compromise (2026-02-20)
- GitHub Advisory GHSA-mrrh-fwg8-r2c3 (tj-actions compromise)
- Unit 42 GitHub Actions supply-chain attack analysis
