### PR TITLE
chore(rules): add malware pattern updates 2026-02-27

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,27 @@
+## 2026-02-27 (1): Double-Extension LNK Masquerade Marker
+
+**Sources:**
+- [The Hacker News - CRESCENTHARVEST Campaign Targets Iran Protest Supporters With RAT Malware](https://thehackernews.com/2026/02/crescentharvest-campaign-targets-iran.html)
+- [Acronis TRU - CRESCENTHARVEST: Iranian protestors and dissidents targeted in cyberespionage campaign](https://www.acronis.com/en/tru/posts/crescentharvest-iranian-protestors-and-dissidents-targeted-in-cyberespionage-campaign/)
+
+**Event Summary:** This week’s campaign reporting describes lure archives that include Windows shortcuts disguised as benign media/document files via double extensions (for example `*.jpg.lnk`, `*.mp4.lnk`). Existing rules already covered command-level execution chains, but did not include a focused static marker for this filename masquerade tactic used in initial-access bundles.
+
+**New Pattern Added:**
+
+### MAL-014: Deceptive media/document double-extension LNK masquerade
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.86
+- **Pattern:** Detects file names that end in media/document extension + `.lnk` (for example `.jpg.lnk`, `.mp4.lnk`, `.pdf.lnk`, `.docx.lnk`).
+- **Justification:** High-signal, low-noise marker for social-engineering lure artifacts that execute shortcut behavior while appearing as non-executable content.
+- **Mitigation:** Quarantine double-extension `.lnk` artifacts and require verified non-shortcut originals for media/document delivery flows.
+
+**Version:** Rules updated from 2026.02.26.2 to 2026.02.27.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_27`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/51_double_extension_lnk_masquerade`.
+
+---
+
 ## 2026-02-26 (2): Claude Code Project MCP Auto-Approval Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -55,6 +55,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `48_vscode_tasks_folderopen_autorun` | Repository-supplied VS Code `tasks.json` task uses `runOn: folderOpen` and an auto-executed shell/bootstrap command, enabling code execution when a workspace is opened | `MAL-012` |
 | `49_osascript_jxa_loader` | macOS `osascript` command executes JavaScript for Automation (`-l JavaScript`) and shell payload staging (`ObjC.import` / `doShellScript`) seen in npm malware chains | `MAL-013` |
 | `50_claude_mcp_autoapprove` | Repository-level Claude Code settings auto-approve project MCP servers (`enableAllProjectMcpServers` / `enabledMcpjsonServers`) and reduce user-consent friction for untrusted tool init | `ABU-003` |
+| `51_double_extension_lnk_masquerade` | Attachment/lure names that masquerade as media or documents via double-extension Windows shortcuts (for example `incident-photo.jpg.lnk`, `street-protest-footage.mp4.lnk`) | `MAL-014` |
 
 ## Commands
 

--- a/examples/showcase/51_double_extension_lnk_masquerade/SKILL.md
+++ b/examples/showcase/51_double_extension_lnk_masquerade/SKILL.md
@@ -1,0 +1,11 @@
+# Double-Extension LNK Masquerade Example
+
+Recent espionage lures used shortcut files that look like media/documents via double extensions.
+
+Suspicious attachment names observed in lure bundles:
+
+- `street-protest-footage.mp4.lnk`
+- `incident-photo.jpg.lnk`
+- `eyewitness-report.pdf.lnk`
+
+These names are intended to look like benign files while executing shortcut payload behavior when opened.

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -52,6 +52,7 @@ Each folder demonstrates one major detection or behavior.
 48. `48_vscode_tasks_folderopen_autorun`: VS Code `tasks.json` auto-run on folder open combined with shell/bootstrap command execution (`MAL-012`)
 49. `49_osascript_jxa_loader`: macOS `osascript` JavaScript for Automation (JXA) execution marker often used in malware loaders (`MAL-013`)
 50. `50_claude_mcp_autoapprove`: repository-level Claude Code MCP auto-approval settings that can bypass expected MCP consent review (`ABU-003`)
+51. `51_double_extension_lnk_masquerade`: deceptive media/document-looking double-extension shortcut filenames (`*.jpg.lnk`, `*.mp4.lnk`, `*.pdf.lnk`) used in lure bundles (`MAL-014`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.26.2"
+version: "2026.02.27.1"
 
 static_rules:
   - id: MAL-001
@@ -290,6 +290,14 @@ static_rules:
     title: Claude Code project MCP auto-approval marker
     pattern: '(?i)"(?:enableAllProjectMcpServers|enabledMcpjsonServers)"\s*:\s*(?:true|\[[^\]]+\])'
     mitigation: Do not commit repository-level MCP auto-approval settings. Require explicit per-project user consent before initializing MCP servers from untrusted repos.
+
+  - id: MAL-014
+    category: malware_pattern
+    severity: high
+    confidence: 0.86
+    title: Deceptive media/document double-extension LNK masquerade
+    pattern: '(?i)\b[\w .-]+\.(?:jpe?g|png|gif|bmp|webp|mp4|mov|avi|mkv|pdf|docx?|xlsx?|pptx?)\.lnk\b'
+    mitigation: Treat media/document-looking `.lnk` files as suspicious. Block or quarantine double-extension shortcut artifacts and require verified non-shortcut originals.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -480,3 +480,15 @@ def test_new_patterns_2026_02_26_patch2() -> None:
         is not None
     )
     assert abu003.pattern.search('"enableAllProjectMcpServers": false') is None
+
+
+def test_new_patterns_2026_02_27() -> None:
+    """Test deceptive media/document double-extension LNK masquerade marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal014 = next((r for r in compiled.static_rules if r.id == "MAL-014"), None)
+    assert mal014 is not None
+    assert mal014.pattern.search("street-protest-footage.mp4.lnk") is not None
+    assert mal014.pattern.search("incident-photo.jpg.lnk") is not None
+    assert mal014.pattern.search("onboarding-video.mp4") is None
+    assert mal014.pattern.search("shortcut-to-tool.lnk") is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -70,6 +70,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "MAL-013" for f in findings_49)
     findings_50 = _scan("examples/showcase/50_claude_mcp_autoapprove").findings
     assert any(f.id == "ABU-003" for f in findings_50)
+    findings_51 = _scan("examples/showcase/51_double_extension_lnk_masquerade").findings
+    assert any(f.id == "MAL-014" for f in findings_51)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add MAL-014 for deceptive media/document double-extension LNK masquerade (e.g., `*.jpg.lnk`, `*.mp4.lnk`)
- bump rulepack version to `2026.02.27.1`
- add showcase fixture `examples/showcase/51_double_extension_lnk_masquerade`
- update showcase/docs indexes and pattern update notes

## Validation
- `.venv/bin/pytest -q` ✅ (107 passed)
- `.venv/bin/ruff check src tests` ✅

## Sources
- https://thehackernews.com/2026/02/crescentharvest-campaign-targets-iran.html
- https://www.acronis.com/en/tru/posts/crescentharvest-iranian-protestors-and-dissidents-targeted-in-cyberespionage-campaign/
