### PR TITLE
chore(rules): add malware pattern updates 2026-03-02

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -59,6 +59,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `52_codespaces_schema_exfil` | Access to Codespaces shared secrets env file plus suspicious remote `$schema` URLs carrying token/data query parameters (potential schema-based exfiltration) | `EXF-011` |
 | `53_claude_base_url_override` | Claude Code project config overrides `ANTHROPIC_BASE_URL` to a non-Anthropic endpoint, enabling API traffic/API key redirection risk in untrusted repos | `EXF-012` |
 | `54_claude_hooks_rce` | Claude Code repo-scoped `.claude/settings.json` hooks (`PreToolUse`/etc.) include shell-capable `command` payloads and form a high-signal hook-execution chain in untrusted projects | `CHN-009`, `MAL-015` |
+| `55_pastebin_stegobin_resolver` | Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) observed in recent StegaBin npm malware loaders | `MAL-016` |
 
 ## Commands
 

--- a/docs/RULE_UPDATES.md
+++ b/docs/RULE_UPDATES.md
@@ -1,5 +1,15 @@
 # Rule Updates
 
+## 2026-03-02
+
+- Added `MAL-016` (high): **Pastebin steganographic dead-drop resolver marker**.
+- Rationale: multiple newly reported npm packages (StegaBin cluster) used hardcoded Pastebin dead-drop URLs with `|||` + `===END===` decoding markers to reconstruct Vercel C2 domains before staging payload execution.
+- Rule scope intentionally requires all core markers (`pastebin.com/<id>`, `|||`, `===END===`, and `vercel.app`) in the same artifact to keep false positives low.
+
+Sources:
+- Socket (2026-03-02), *StegaBin: 26 Malicious npm Packages Use Pastebin Steganography*: https://socket.dev/blog/stegabin-26-malicious-npm-packages-use-pastebin-steganography
+- The Hacker News (2026-03-02), *North Korean Hackers Publish 26 npm Packages Hiding Pastebin C2 for Cross-Platform RAT*: https://thehackernews.com/2026/03/north-korean-hackers-publish-26-npm.html
+
 ## 2026-02-25
 
 - Added `MAL-012` (high): **VS Code task autorun-on-folder-open marker**.

--- a/examples/showcase/55_pastebin_stegobin_resolver/SKILL.md
+++ b/examples/showcase/55_pastebin_stegobin_resolver/SKILL.md
@@ -1,0 +1,15 @@
+# StegaBin-style Pastebin dead-drop resolver
+
+This showcase demonstrates a high-signal static marker observed in recent npm malware campaigns:
+- Pastebin dead-drop URL
+- `|||` separator
+- `===END===` terminator
+- decoded Vercel C2 domain reference
+
+```js
+const fallbackPastes = ["https://pastebin.com/CJ5PrtNk"];
+const marker = "|||";
+const endMarker = "===END===";
+const decoded = "ext-checkdin.vercel.app";
+const deadDrop = "https://pastebin.com/CJ5PrtNk|||ext-checkdin.vercel.app===END===";
+```

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -56,6 +56,7 @@ Each folder demonstrates one major detection or behavior.
 52. `52_codespaces_schema_exfil`: Codespaces secrets file access plus suspicious remote JSON schema URL data-exfil markers (`EXF-011`)
 53. `53_claude_base_url_override`: Claude Code project config overrides `ANTHROPIC_BASE_URL` to a non-Anthropic endpoint (API key exfiltration risk, `EXF-012`)
 54. `54_claude_hooks_rce`: Claude Code project `hooks` config executes shell commands in repository-scoped settings (`CHN-009`, `MAL-015`)
+55. `55_pastebin_stegobin_resolver`: Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) associated with StegaBin npm campaign (`MAL-016`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.02.28.2"
+version: "2026.03.02.1"
 
 static_rules:
   - id: MAL-001
@@ -325,6 +325,14 @@ static_rules:
     title: Claude Code hooks shell command execution marker
     pattern: '(?is)"hooks"\s*:\s*\{[\s\S]{0,2000}"(?:PreToolUse|PostToolUse|UserPromptSubmit|SessionStart)"[\s\S]{0,800}"command"\s*:\s*"(?:bash|sh|zsh|powershell|pwsh|cmd(?:\.exe)?|python3?\s+-c|node\s+-e)[^"\n]{0,240}'
     mitigation: Treat repository-scoped Claude Code hooks as untrusted. Remove auto-executed shell commands from `.claude/settings.json` and require explicit, reviewed local scripts.
+
+  - id: MAL-016
+    category: malware_pattern
+    severity: high
+    confidence: 0.84
+    title: Pastebin steganographic dead-drop resolver marker
+    pattern: '(?i)pastebin\.com/[A-Za-z0-9]{6,10}[^\n]{0,220}\|\|\|[^\n]{0,220}(?:vercel\.app[^\n]{0,220}===END===|===END===[^\n]{0,220}vercel\.app)'
+    mitigation: Treat install-time loaders that decode C2 from Pastebin text as malicious. Remove dead-drop resolver logic and block outbound execution of decoded domains.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -564,3 +564,24 @@ def test_new_patterns_2026_02_28_patch2() -> None:
         )
         is None
     )
+
+
+def test_new_patterns_2026_03_02() -> None:
+    """Test Pastebin steganographic dead-drop resolver marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal016 = next((r for r in compiled.static_rules if r.id == "MAL-016"), None)
+    assert mal016 is not None
+    assert (
+        mal016.pattern.search(
+            "const p='https://pastebin.com/CJ5PrtNk'; const s='|||'; "
+            "const e='===END==='; const c2='ext-checkdin.vercel.app';"
+        )
+        is not None
+    )
+    assert (
+        mal016.pattern.search(
+            "const p='https://pastebin.com/CJ5PrtNk'; const c2='ext-checkdin.vercel.app';"
+        )
+        is None
+    )

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -78,6 +78,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "EXF-012" for f in findings_53)
     findings_54 = _scan("examples/showcase/54_claude_hooks_rce").findings
     assert any(f.id == "CHN-009" for f in findings_54)
+    findings_55 = _scan("examples/showcase/55_pastebin_stegobin_resolver").findings
+    assert any(f.id == "MAL-016" for f in findings_55)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary\n- add MAL-016 Pastebin steganographic dead-drop resolver marker for StegaBin-style npm loaders\n- bump builtin rules version to 2026.03.02.1\n- add showcase fixture 55_pastebin_stegobin_resolver\n- update docs and tests for new pattern\n\n## Validation\n- .venv/bin/pytest -q\n- .venv/bin/ruff check src tests\n\n## Sources\n- https://socket.dev/blog/stegabin-26-malicious-npm-packages-use-pastebin-steganography\n- https://thehackernews.com/2026/03/north-korean-hackers-publish-26-npm.html