### PR TITLE
chore(rules): add malware pattern updates 2026-03-04

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -745,3 +745,27 @@
 **Version:** Rules updated from 2026.02.19.1 to 2026.02.19.2
 
 **Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_02_19_patch2` and `tests/test_showcase_examples.py`.
+
+---
+
+## 2026-03-04: Tool Auto-Approve Package-Install Command Pattern
+
+**Sources:**
+- https://github.com/RooCodeInc/Roo-Code/security/advisories/GHSA-c292-qxq4-4p2v
+- https://docs.roocode.com/update-notes/v3.26.0
+
+**Event Summary:** A disclosed Roo Code issue shows that enabling auto-approval for terminal commands can permit `npm install` execution without an explicit approval step. Because package installs can execute lifecycle scripts (`preinstall`/`postinstall`), this creates a realistic arbitrary-code-execution path when opening untrusted repositories.
+
+**New Pattern Added:**
+
+### ABU-004: Tool auto-approve allowlist includes package-install command
+- **Category:** instruction_abuse
+- **Severity:** high
+- **Confidence:** 0.84
+- **Pattern:** Detects package-install commands (`npm/pnpm/yarn/bun install`) in proximity to auto-approve/command-allowlist markers.
+- **Justification:** Captures high-signal tool settings that lower consent barriers before install-time script execution.
+- **Mitigation:** Remove package-install commands from auto-approved command lists; require explicit human confirmation for install actions.
+
+**Version:** Rules updated from 2026.03.03.1 to 2026.03.04.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_03_04` and `tests/test_showcase_examples.py` with showcase fixture `examples/showcase/58_tool_autoapprove_pkg_install`.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -62,6 +62,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `55_pastebin_stegobin_resolver` | Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) observed in recent StegaBin npm malware loaders | `MAL-016` |
 | `56_hex_decode_exec` | Hex-decoded command string (`Buffer.from(...,'hex').toString()`) followed by immediate `child_process` execution (`exec`/`spawn`) as seen in recent npm malware install chains | `SUP-009` |
 | `57_install_websocket_c2` | npm install script (`preinstall` + `install.js`) opens a WebSocket C2 channel and executes received commands via shell-capable process spawn | `MAL-017` |
+| `58_tool_autoapprove_pkg_install` | Tool/extension auto-approve command settings include package-install commands (`npm/pnpm/yarn/bun install`), reducing user-consent guardrails before install-time script execution | `ABU-004` |
 
 ## Commands
 

--- a/examples/showcase/58_tool_autoapprove_pkg_install/settings.json
+++ b/examples/showcase/58_tool_autoapprove_pkg_install/settings.json
@@ -1,0 +1,1 @@
+{"autoApprove":true,"allowedCommands":["git status","npm install","pnpm install --frozen-lockfile"],"notes":"Convenience setup for trusted repos"}

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -59,6 +59,7 @@ Each folder demonstrates one major detection or behavior.
 55. `55_pastebin_stegobin_resolver`: Pastebin dead-drop steganography markers (`pastebin` URL + `|||` + `===END===` + `vercel.app`) associated with StegaBin npm campaign (`MAL-016`)
 56. `56_hex_decode_exec`: Hex-decoded command strings immediately executed via `child_process` (`Buffer.from(...,'hex').toString()` + `exec/spawn`) as seen in recent npm malware install chains (`SUP-009`)
 57. `57_install_websocket_c2`: npm install-script (`preinstall` + `install.js`) opens WebSocket C2 and executes received shell commands (`spawn`/`exec`) (`MAL-017`)
+58. `58_tool_autoapprove_pkg_install`: tool/extension auto-approve settings that allow package-install commands (`npm/pnpm/yarn/bun install`) without confirmation (`ABU-004`)
 
 ## Run examples
 

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.03.1"
+version: "2026.03.04.1"
 
 static_rules:
   - id: MAL-001
@@ -350,6 +350,14 @@ static_rules:
     pattern: '(?is)(?:new\s+WebSocket\s*\(|\bWebSocket\s*\(|\bwss?://(?:\d{1,3}\.){3}\d{1,3}:\d{2,5})[\s\S]{0,320}(?:exec|execSync|spawn|spawnSync)\s*\([^
 ]{0,180}(?:/bin/sh|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh)?'
     mitigation: Treat WebSocket command channels that launch shell/process execution as malicious. Remove package/runtime code that combines outbound WebSocket control paths with command execution primitives.
+
+  - id: ABU-004
+    category: instruction_abuse
+    severity: high
+    confidence: 0.84
+    title: Tool auto-approve allowlist includes package-install command
+    pattern: '(?is)(?:auto[- ]?approve|always\s+approve|allowed\s+commands|command\s+allowlist)[\s\S]{0,220}\b(?:npm\s+(?:install|i)|pnpm\s+install|yarn\s+install|bun\s+install)\b|\b(?:npm\s+(?:install|i)|pnpm\s+install|yarn\s+install|bun\s+install)\b[\s\S]{0,220}(?:auto[- ]?approve|always\s+approve|allowed\s+commands|command\s+allowlist)'
+    mitigation: Do not auto-approve package-install commands in AI tool/extension settings. Require explicit user confirmation for install actions because lifecycle scripts can execute arbitrary code.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -608,3 +608,29 @@ def test_new_patterns_2026_03_02_patch2() -> None:
         )
         is None
     )
+
+
+def test_new_patterns_2026_03_04() -> None:
+    """Test tool auto-approve + package-install command marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    abu004 = next((r for r in compiled.static_rules if r.id == "ABU-004"), None)
+    assert abu004 is not None
+    assert (
+        abu004.pattern.search(
+            '{"autoApprove":true,"allowedCommands":["npm install","git status"]}'
+        )
+        is not None
+    )
+    assert (
+        abu004.pattern.search(
+            "Always approve terminal commands: pnpm install --frozen-lockfile"
+        )
+        is not None
+    )
+    assert (
+        abu004.pattern.search(
+            '{"autoApprove":true,"allowedCommands":["git status","npm test"]}'
+        )
+        is None
+    )

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -84,6 +84,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "SUP-009" for f in findings_56)
     findings_57 = _scan("examples/showcase/57_install_websocket_c2").findings
     assert any(f.id == "MAL-017" for f in findings_57)
+    findings_58 = _scan("examples/showcase/58_tool_autoapprove_pkg_install").findings
+    assert any(f.id == "ABU-004" for f in findings_58)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add ABU-004 to detect tool/extension auto-approve command allowlists that include package install commands (npm/pnpm/yarn/bun)
- bump ruleset version to 2026.03.04.1
- add showcase fixture examples/showcase/58_tool_autoapprove_pkg_install
- update showcase/docs mappings and tests

## Validation
- .venv/bin/pytest -q (113 passed)
- .venv/bin/ruff check src tests (passed)

## Sources
- https://github.com/RooCodeInc/Roo-Code/security/advisories/GHSA-c292-qxq4-4p2v
- https://docs.roocode.com/update-notes/v3.26.0