### PR TITLE
build: add PyPI/Docker release workflows + distribution docs refresh

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,45 @@
+name: Release Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/skillscan
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,86 @@
+name: Release PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build + dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]' build
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Smoke install from built wheel
+        run: |
+          python -m venv /tmp/skillscan-smoke
+          source /tmp/skillscan-smoke/bin/activate
+          pip install --upgrade pip
+          pip install dist/*.whl
+          skillscan --help > /dev/null
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum * > SHA256SUMS
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+  publish:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/skillscan
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  github-release:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -6,12 +6,12 @@ This document describes supported ways to install and operate SkillScan in local
 
 | Path | Best for | Command |
 |---|---|---|
-| PyPI (planned) | End users / CI | `pip install skillscan` |
-| Docker (planned) | Reproducible CI, isolated runtime | `docker run --rm -v "$PWD:/work" <image> scan /work` |
-| Source/dev (current) | Contributors | `pip install -e '.[dev]'` |
-| Convenience script (current) | Quick local bootstrap | `curl -fsSL .../scripts/install.sh \| bash` |
+| PyPI | End users / CI | `pip install skillscan` |
+| Docker | Reproducible CI, isolated runtime | `docker run --rm -v "$PWD:/work" <image> scan /work` |
+| Source/dev | Contributors | `pip install -e '.[dev]'` |
+| Convenience script | Quick local bootstrap | `curl -fsSL .../scripts/install.sh \| bash` |
 
-> Note: PyPI and DockerHub publication are tracked in roadmap issues and may be in-progress.
+> Release automation is wired through GitHub Actions tag workflows (`release-pypi.yml`, `release-docker.yml`).
 
 ---
 
@@ -42,9 +42,7 @@ If using a fork/private location, set `SKILLSCAN_REPO_URL` first.
 
 ---
 
-## Planned PyPI Install (Issue #43)
-
-Once PyPI publishing is enabled:
+## PyPI Install
 
 ```bash
 pip install skillscan
@@ -59,9 +57,7 @@ pip install "skillscan==X.Y.Z"
 
 ---
 
-## Planned Docker Usage (Issue #44)
-
-Once DockerHub publishing is enabled:
+## Docker Usage
 
 ```bash
 docker run --rm -v "$PWD:/work" <image>:<tag> skillscan scan /work --fail-on never
@@ -122,6 +118,15 @@ docker pull <image>:<previous-tag>
 ```
 
 ---
+
+## Release Automation Notes
+
+- PyPI publish runs on `v*` tags via `.github/workflows/release-pypi.yml`.
+- Docker multi-arch publish runs on `v*` tags via `.github/workflows/release-docker.yml`.
+- Required GitHub secrets for Docker publish:
+  - `DOCKERHUB_USERNAME`
+  - `DOCKERHUB_TOKEN`
+- PyPI publish is configured for trusted publishing (`id-token: write`) with environment `pypi`.
 
 ## CI Recommendations
 


### PR DESCRIPTION
## Summary
- add tag-triggered PyPI release workflow with build/test/smoke install/checksums
- add tag-triggered DockerHub multi-arch publish workflow (amd64/arm64)
- refresh docs/DISTRIBUTION.md with release automation notes and install paths

## Validation
- .venv/bin/pytest -q
- tests/test_showcase_examples.py::test_showcase_detection_rules
