### PR TITLE
chore(rules): add malware pattern updates 2026-03-06

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,27 @@
+## 2026-03-06 (1): Bracket-Glob Sensitive Path Obfuscation Marker
+
+**Sources:**
+- [GitHub Advisory Database - GHSA-5wp8-q9mx-8jx8](https://github.com/advisories/GHSA-5wp8-q9mx-8jx8)
+- [zeptoclaw Advisory - Shell allowlist/blocklist bypass](https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-5wp8-q9mx-8jx8)
+
+**Event Summary:** GHSA-5wp8-q9mx-8jx8 documents bypasses in shell guard logic where literal path blocklists can be evaded by bracket-glob obfuscation (for example `/etc/pass[w]d`). Existing SkillScan rules matched direct sensitive paths but did not include this evasive variant.
+
+**New Pattern Added:**
+
+### EXF-014: Bracket-glob obfuscated sensitive path marker
+- **Category:** exfiltration
+- **Severity:** high
+- **Confidence:** 0.85
+- **Pattern:** Detects bracket-glob variants of high-risk secret paths (`/etc/pass[w]d`, `/etc/shad[o]w`, `~/.ssh/id_r[s]a`) commonly used to evade literal denylist checks.
+- **Justification:** High-signal marker tied to a concrete, recent advisory and narrowly scoped to sensitive-path obfuscation behavior with low expected false positives.
+- **Mitigation:** Normalize/resolve glob metacharacters before path denylist checks and reject obfuscated sensitive path access attempts.
+
+**Version:** Rules updated from 2026.03.05.2 to 2026.03.06.1
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_03_06`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/61_bracket_glob_secret_path_bypass`.
+
+---
+
 ## 2026-03-05 (2): node-glob CLI `-c/--cmd` Shell Injection Sink Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -65,6 +65,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `58_tool_autoapprove_pkg_install` | Tool/extension auto-approve command settings include package-install commands (`npm/pnpm/yarn/bun install`), reducing user-consent guardrails before install-time script execution | `ABU-004` |
 | `59_mcp_global_config_injection` | Repository/setup instructions write `mcpServers` entries directly into user-home assistant config files (`~/.cursor/mcp.json`, `~/.claude/settings.json`, etc.) with executable server commands | `EXF-013` |
 | `60_glob_cmd_shell_injection` | `glob` CLI command execution mode (`-c`/`--cmd`) on untrusted filenames, where shell metacharacters in file paths can trigger arbitrary command execution | `MAL-018` |
+| `61_bracket_glob_secret_path_bypass` | Bracket-glob obfuscation of sensitive file paths (for example `/etc/pass[w]d`, `/etc/shad[o]w`, `~/.ssh/id_r[s]a`) used to bypass literal denylist checks in shell/tool security guards | `EXF-014` |
 
 ## Commands
 

--- a/examples/showcase/61_bracket_glob_secret_path_bypass/SKILL.md
+++ b/examples/showcase/61_bracket_glob_secret_path_bypass/SKILL.md
@@ -1,0 +1,12 @@
+# Bracket-Glob Sensitive Path Bypass Showcase
+
+This fixture mirrors GHSA-5wp8-q9mx-8jx8 style blocklist bypass where bracket globs obfuscate sensitive file paths.
+
+```bash
+# Looks like a benign variant to naive substring filters
+cat /etc/pass[w]d
+cat /etc/shad[o]w
+cat ~/.ssh/id_r[s]a
+```
+
+If path checks only match exact literals (for example `/etc/passwd`), bracket-glob variants can evade detection.

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -75,3 +75,4 @@ skillscan scan examples/showcase/28_npx_registry_fallback --fail-on never
 skillscan scan examples/showcase/29_claude_sed_path_bypass --fail-on never
 ```
 60. `60_glob_cmd_shell_injection`: node-glob CLI `-c/--cmd` usage that can evaluate attacker-controlled filename metacharacters via shell execution context (`MAL-018`)
+61. `61_bracket_glob_secret_path_bypass`: bracket-glob obfuscation of sensitive file paths (`/etc/pass[w]d`, `/etc/shad[o]w`, `~/.ssh/id_r[s]a`) used to evade literal denylist checks (`EXF-014`)

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.05.2"
+version: "2026.03.06.1"
 
 static_rules:
   - id: MAL-001
@@ -375,6 +375,14 @@ static_rules:
     title: Tool auto-approve allowlist includes package-install command
     pattern: '(?is)(?:auto[- ]?approve|always\s+approve|allowed\s+commands|command\s+allowlist)[\s\S]{0,220}\b(?:npm\s+(?:install|i)|pnpm\s+install|yarn\s+install|bun\s+install)\b|\b(?:npm\s+(?:install|i)|pnpm\s+install|yarn\s+install|bun\s+install)\b[\s\S]{0,220}(?:auto[- ]?approve|always\s+approve|allowed\s+commands|command\s+allowlist)'
     mitigation: Do not auto-approve package-install commands in AI tool/extension settings. Require explicit user confirmation for install actions because lifecycle scripts can execute arbitrary code.
+
+  - id: EXF-014
+    category: exfiltration
+    severity: high
+    confidence: 0.85
+    title: Bracket-glob obfuscated sensitive path marker
+    pattern: '(?i)(?:/etc/pass\[[^\]\n]{1,4}\]d|/etc/shad\[[^\]\n]{1,4}\]w|\.ssh/id_r\[[^\]\n]{1,4}\]a)'
+    mitigation: Treat bracket-glob path obfuscation as suspicious when accessing sensitive files. Normalize/resolve glob metacharacters before blocklist checks and reject obfuscated sensitive path reads.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -672,3 +672,15 @@ def test_new_patterns_2026_03_05_patch2() -> None:
     assert mal018.pattern.search('npx glob -c echo "**/*"') is not None
     assert mal018.pattern.search('glob --cmd "echo" "src/**/*.ts"') is not None
     assert mal018.pattern.search('glob "src/**/*.ts"') is None
+
+
+def test_new_patterns_2026_03_06() -> None:
+    """Test bracket-glob obfuscated sensitive path marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    exf014 = next((r for r in compiled.static_rules if r.id == "EXF-014"), None)
+    assert exf014 is not None
+    assert exf014.pattern.search("cat /etc/pass[w]d") is not None
+    assert exf014.pattern.search("cat /etc/shad[o]w") is not None
+    assert exf014.pattern.search("cat ~/.ssh/id_r[s]a") is not None
+    assert exf014.pattern.search("cat /etc/passwd") is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -90,6 +90,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "EXF-013" for f in findings_59)
     findings_60 = _scan("examples/showcase/60_glob_cmd_shell_injection").findings
     assert any(f.id == "MAL-018" for f in findings_60)
+    findings_61 = _scan("examples/showcase/61_bracket_glob_secret_path_bypass").findings
+    assert any(f.id == "EXF-014" for f in findings_61)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add EXF-014 bracket-glob obfuscated sensitive-path marker (GHSA-5wp8-q9mx-8jx8 inspired)
- bump rules version to 2026.03.06.1
- add showcase fixture 61_bracket_glob_secret_path_bypass
- update showcase/docs indexes and pattern update notes
- add rule + showcase tests

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests
