### PR TITLE
feat(render): add finding narratives with confidence labels

### DIFF
--- a/src/skillscan/models.py
+++ b/src/skillscan/models.py
@@ -32,6 +32,26 @@ class Finding(BaseModel):
     mitigation: str | None = None
 
 
+
+
+class ConfidenceLabel(StrEnum):
+    EXPERIMENTAL = "experimental"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+def confidence_label(confidence: float) -> ConfidenceLabel:
+    """Map a 0.0-1.0 confidence score to a human-readable label."""
+    if confidence < 0.5:
+        return ConfidenceLabel.EXPERIMENTAL
+    if confidence < 0.7:
+        return ConfidenceLabel.LOW
+    if confidence < 0.85:
+        return ConfidenceLabel.MEDIUM
+    return ConfidenceLabel.HIGH
+
+
 class IOC(BaseModel):
     value: str
     kind: str

--- a/src/skillscan/render.py
+++ b/src/skillscan/render.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from skillscan.models import Finding, ScanReport, Verdict
+from skillscan.models import Finding, ScanReport, Verdict, confidence_label
 
 VERDICT_STYLE = {
     Verdict.ALLOW: "bold green",
@@ -16,7 +16,8 @@ VERDICT_STYLE = {
 
 
 def _finding_narrative(finding: Finding) -> tuple[str, str, str]:
-    why = f"Matched {finding.id} ({finding.category})"
+    clabel = confidence_label(finding.confidence)
+    why = f"Matched {finding.id} ({finding.category}) [{clabel.value} confidence]"
     impact = f"Potential {finding.severity.value}-severity security risk"
     next_action = finding.mitigation or "Review the flagged snippet and remove/contain risky behavior"
     return why, impact, next_action
@@ -63,6 +64,7 @@ def render_report(report: ScanReport, console: Console | None = None) -> None:
     findings.add_column("Severity")
     findings.add_column("Category")
     findings.add_column("Evidence")
+    findings.add_column("Confidence", style="dim")
     findings.add_column("Snippet")
     findings.add_column("Why")
     findings.add_column("Impact")
@@ -74,6 +76,7 @@ def render_report(report: ScanReport, console: Console | None = None) -> None:
             finding.severity.value,
             finding.category,
             f"{finding.evidence_path}:{finding.line or '-'}",
+            confidence_label(finding.confidence).value,
             finding.snippet[:90],
             why[:80],
             impact[:80],

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -6,12 +6,14 @@ from skillscan.models import (
     IOC,
     AIAssessment,
     Capability,
+    ConfidenceLabel,
     DependencyFinding,
     Finding,
     ScanMetadata,
     ScanReport,
     Severity,
     Verdict,
+    confidence_label,
 )
 from skillscan.render import _category_counts, _finding_narrative, _recommended_actions, render_report
 
@@ -109,6 +111,34 @@ def test_recommended_actions_and_categories() -> None:
     cats = _category_counts(report)
     assert cats[0] == ("instruction_abuse", 2)
 
+
+def test_confidence_label_bands() -> None:
+    assert confidence_label(0.3) == ConfidenceLabel.EXPERIMENTAL
+    assert confidence_label(0.49) == ConfidenceLabel.EXPERIMENTAL
+    assert confidence_label(0.5) == ConfidenceLabel.LOW
+    assert confidence_label(0.69) == ConfidenceLabel.LOW
+    assert confidence_label(0.7) == ConfidenceLabel.MEDIUM
+    assert confidence_label(0.84) == ConfidenceLabel.MEDIUM
+    assert confidence_label(0.85) == ConfidenceLabel.HIGH
+    assert confidence_label(1.0) == ConfidenceLabel.HIGH
+
+
+def test_finding_narrative_includes_confidence() -> None:
+    finding = Finding(
+        id="MAL-001",
+        category="malware_pattern",
+        severity=Severity.CRITICAL,
+        confidence=0.95,
+        title="test",
+        evidence_path="a",
+        snippet="x",
+        mitigation="remove it",
+    )
+    why, impact, next_action = _finding_narrative(finding)
+    assert "high confidence" in why
+    assert "critical" in impact
+
+
 def test_render_report_full_sections() -> None:
     report = ScanReport(
         metadata=_base_metadata(),
@@ -153,5 +183,6 @@ def test_render_report_full_sections() -> None:
     assert "Network Indicators" in output
     assert "Dependency Vulnerabilities" in output
     assert "AI Assist" in output
+    assert "Confi" in output
     assert "Finding Categories" in output
     assert "Recommended Actions" in output


### PR DESCRIPTION
## Summary
- add finding narratives in text render with explicit:
  - why fired
  - likely impact
  - next action
- introduce confidence label bands for findings (`experimental|low|medium|high`)
- include confidence label in the narrative and report table output
- extend render tests to cover confidence bands and narrative content

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/pytest -q`
- Result: `128 passed`
