### PR TITLE
feat(policy): confidence threshold gating for BLOCK verdicts

### DIFF
--- a/src/skillscan/analysis.py
+++ b/src/skillscan/analysis.py
@@ -913,9 +913,13 @@ def scan(
                 )
 
         score = 0
+        block_score = 0
         for finding in findings:
             weight = policy.weights.get(finding.category, 1)
-            score += SEVERITY_SCORE[finding.severity] * weight
+            contribution = SEVERITY_SCORE[finding.severity] * weight
+            score += contribution
+            if finding.confidence >= policy.block_min_confidence:
+                block_score += contribution
 
         ai_critical_block = any(
             f.category == "ai_semantic_risk"
@@ -924,11 +928,13 @@ def scan(
             for f in findings
         )
 
-        if any(f.id in policy.hard_block_rules for f in findings):
+        if any(
+            f.id in policy.hard_block_rules and f.confidence >= policy.block_min_confidence for f in findings
+        ):
             verdict = Verdict.BLOCK
         elif policy.ai_block_on_critical and ai_critical_block:
             verdict = Verdict.BLOCK
-        elif score >= policy.thresholds["block"]:
+        elif block_score >= policy.thresholds["block"]:
             verdict = Verdict.BLOCK
         elif score >= policy.thresholds["warn"]:
             verdict = Verdict.WARN

--- a/src/skillscan/models.py
+++ b/src/skillscan/models.py
@@ -118,6 +118,7 @@ class Policy(BaseModel):
     block_domains: list[str] = Field(default_factory=list)
     ai_block_on_critical: bool = True
     ai_block_min_confidence: float = Field(default=0.85, ge=0.0, le=1.0)
+    block_min_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     limits: dict[str, int] = Field(
         default_factory=lambda: {
             "max_files": 4000,

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -250,3 +250,41 @@ def test_python_bytecode_is_flagged(tmp_path: Path) -> None:
     policy = load_builtin_policy("strict")
     report = scan(target, policy, "builtin:strict")
     assert any(f.id == "BIN-004" for f in report.findings)
+
+
+def test_block_min_confidence_prevents_hard_block_for_low_confidence_rule() -> None:
+    policy = Policy.model_validate(
+        {
+            "name": "strict-conf",
+            "description": "strict with confidence gate",
+            "thresholds": {"warn": 10000, "block": 1},
+            "weights": {"instruction_abuse": 1},
+            "hard_block_rules": ["ABU-001"],
+            "block_min_confidence": 0.95,
+            "allow_domains": [],
+            "block_domains": [],
+            "limits": {"max_files": 1000, "max_depth": 6, "max_bytes": 5000000, "timeout_seconds": 30},
+        }
+    )
+    report = scan("examples/showcase/03_instruction_abuse", policy, "custom")
+    assert any(f.id == "ABU-001" for f in report.findings)
+    assert report.verdict != Verdict.BLOCK
+
+
+def test_block_min_confidence_allows_block_when_threshold_met() -> None:
+    policy = Policy.model_validate(
+        {
+            "name": "strict-conf",
+            "description": "strict with confidence gate",
+            "thresholds": {"warn": 10000, "block": 1},
+            "weights": {"instruction_abuse": 1},
+            "hard_block_rules": ["ABU-001"],
+            "block_min_confidence": 0.5,
+            "allow_domains": [],
+            "block_domains": [],
+            "limits": {"max_files": 1000, "max_depth": 6, "max_bytes": 5000000, "timeout_seconds": 30},
+        }
+    )
+    report = scan("examples/showcase/03_instruction_abuse", policy, "custom")
+    assert any(f.id == "ABU-001" for f in report.findings)
+    assert report.verdict == Verdict.BLOCK


### PR DESCRIPTION
## Summary
- add `block_min_confidence` policy field to gate BLOCK verdict scoring/hard-blocks
- compute `block_score` from findings meeting confidence threshold
- apply confidence gate to hard-block rule evaluation
- keep WARN scoring behavior unchanged (full score still used for warn threshold)
- add targeted tests for confidence gate behavior

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/pytest -q tests/test_scan.py::test_block_min_confidence_prevents_hard_block_for_low_confidence_rule tests/test_scan.py::test_block_min_confidence_allows_block_when_threshold_met`
