### PR TITLE
feat(policy): file-type aware binary scope limits

### DIFF
--- a/src/skillscan/analysis.py
+++ b/src/skillscan/analysis.py
@@ -259,11 +259,18 @@ def _classify_non_text(path: Path) -> BinaryArtifact | None:
     return None
 
 
-def iter_text_files(root: Path, max_files: int, max_bytes: int) -> FileInventory:
+def iter_text_files(
+    root: Path,
+    max_files: int,
+    max_bytes: int,
+    max_binary_artifacts: int,
+    max_binary_bytes: int,
+) -> FileInventory:
     files: list[Path] = []
     binary_artifacts: list[BinaryArtifact] = []
     total_bytes = 0
     total_files = 0
+    total_binary_bytes = 0
     for path in root.rglob("*"):
         if not path.is_file():
             continue
@@ -280,6 +287,11 @@ def iter_text_files(root: Path, max_files: int, max_bytes: int) -> FileInventory
         classification = _classify_non_text(path)
         if classification is not None:
             binary_artifacts.append(classification)
+            total_binary_bytes += size
+            if len(binary_artifacts) > max_binary_artifacts:
+                raise ScanError("Binary artifact count exceeded max_binary_artifacts policy limit")
+            if total_binary_bytes > max_binary_bytes:
+                raise ScanError("Binary artifact bytes exceeded max_binary_bytes policy limit")
             continue
         files.append(path)
     return FileInventory(text_files=files, binary_artifacts=binary_artifacts)
@@ -606,7 +618,13 @@ def scan(
     )
     try:
         ruleset: CompiledRulePack = load_compiled_builtin_rulepack()
-        inventory = iter_text_files(prepared.root, policy.limits["max_files"], policy.limits["max_bytes"])
+        inventory = iter_text_files(
+            prepared.root,
+            policy.limits["max_files"],
+            policy.limits["max_bytes"],
+            policy.limits.get("max_binary_artifacts", 500),
+            policy.limits.get("max_binary_bytes", 100_000_000),
+        )
         files = inventory.text_files
         findings: list[Finding] = []
         iocs: list[IOC] = []

--- a/src/skillscan/data/policies/balanced.yaml
+++ b/src/skillscan/data/policies/balanced.yaml
@@ -19,3 +19,5 @@ limits:
   max_depth: 8
   max_bytes: 250000000
   timeout_seconds: 75
+  max_binary_artifacts: 700
+  max_binary_bytes: 125000000

--- a/src/skillscan/data/policies/permissive.yaml
+++ b/src/skillscan/data/policies/permissive.yaml
@@ -18,3 +18,5 @@ limits:
   max_depth: 10
   max_bytes: 350000000
   timeout_seconds: 90
+  max_binary_artifacts: 1000
+  max_binary_bytes: 175000000

--- a/src/skillscan/data/policies/strict.yaml
+++ b/src/skillscan/data/policies/strict.yaml
@@ -20,3 +20,5 @@ limits:
   max_depth: 8
   max_bytes: 200000000
   timeout_seconds: 60
+  max_binary_artifacts: 500
+  max_binary_bytes: 100000000

--- a/src/skillscan/models.py
+++ b/src/skillscan/models.py
@@ -125,6 +125,8 @@ class Policy(BaseModel):
             "max_depth": 8,
             "max_bytes": 200_000_000,
             "timeout_seconds": 60,
+            "max_binary_artifacts": 500,
+            "max_binary_bytes": 100_000_000,
         }
     )
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from skillscan.ai import AIResult
-from skillscan.analysis import scan
+from skillscan.analysis import ScanError, scan
 from skillscan.intel import add_source
 from skillscan.models import AIAssessment, Finding, Policy, Severity, Verdict
 from skillscan.policies import load_builtin_policy
@@ -250,6 +250,38 @@ def test_python_bytecode_is_flagged(tmp_path: Path) -> None:
     policy = load_builtin_policy("strict")
     report = scan(target, policy, "builtin:strict")
     assert any(f.id == "BIN-004" for f in report.findings)
+
+
+def test_binary_artifact_count_limit(tmp_path: Path) -> None:
+    target = tmp_path / "bundle"
+    target.mkdir(parents=True)
+    (target / "a.bin").write_bytes(b"\x00\x01\x02\x03")
+    (target / "b.bin").write_bytes(b"\x00\x01\x02\x03")
+
+    policy = load_builtin_policy("strict")
+    policy.limits["max_binary_artifacts"] = 1
+
+    try:
+        scan(target, policy, "builtin:strict")
+        assert False, "expected ScanError"
+    except ScanError as exc:
+        assert "max_binary_artifacts" in str(exc)
+
+
+def test_binary_artifact_bytes_limit(tmp_path: Path) -> None:
+    target = tmp_path / "bundle"
+    target.mkdir(parents=True)
+    (target / "a.bin").write_bytes(b"\x00" * 50)
+    (target / "b.bin").write_bytes(b"\x00" * 60)
+
+    policy = load_builtin_policy("strict")
+    policy.limits["max_binary_bytes"] = 100
+
+    try:
+        scan(target, policy, "builtin:strict")
+        assert False, "expected ScanError"
+    except ScanError as exc:
+        assert "max_binary_bytes" in str(exc)
 
 
 def test_block_min_confidence_prevents_hard_block_for_low_confidence_rule() -> None:


### PR DESCRIPTION
## Summary
- add file-type aware binary scope limits in policy `limits`:
  - `max_binary_artifacts`
  - `max_binary_bytes`
- enforce both limits in scan inventory traversal
- wire defaults into strict/balanced/permissive built-in policy profiles
- add tests for:
  - binary artifact count limit
  - binary artifact bytes limit

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/pytest -q tests/test_scan.py::test_binary_artifact_count_limit tests/test_scan.py::test_binary_artifact_bytes_limit tests/test_scan.py::test_python_bytecode_is_flagged`
