### PR TITLE
chore(rules): add malware pattern updates 2026-03-06

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,27 @@
+## 2026-03-06 (2): StegaBin Shared npm Payload-Path Marker
+
+**Sources:**
+- [Socket - StegaBin: 26 Malicious npm Packages Use Pastebin Steganography](https://socket.dev/blog/stegabin-26-malicious-npm-packages-use-pastebin-steganography)
+- [The Hacker News - North Korean Hackers Publish 26 npm Packages Hiding Pastebin C2 for Cross-Platform RAT](https://thehackernews.com/2026/03/north-korean-hackers-publish-26-npm.html)
+
+**Event Summary:** Socket’s March 2026 write-up documents 26 typosquat npm packages that shared a common malicious loader component at `vendor/scrypt-js/version.js`, executed through install-hook chains. Existing SkillScan rules covered generalized install-hook abuse and steganographic dead-drop behavior but did not include a focused static marker for this concrete, campaign-linked payload path.
+
+**New Pattern Added:**
+
+### MAL-019: StegaBin npm shared payload path marker
+- **Category:** malware_pattern
+- **Severity:** high
+- **Confidence:** 0.86
+- **Pattern:** Detects references to `vendor/scrypt-js/version.js` in repository/package artifacts.
+- **Justification:** High-signal and low-noise campaign marker tied to recent public reporting; suitable as an explicit static signature alongside broader behavioral patterns.
+- **Mitigation:** Remove package content referencing this path, verify package provenance, and avoid installing typosquat dependencies from untrusted publishers.
+
+**Version:** Rules updated from 2026.03.06.1 to 2026.03.06.2
+
+**Testing:** Added coverage in `tests/test_rules.py::test_new_patterns_2026_03_06_patch2`, showcase validation in `tests/test_showcase_examples.py`, and fixture `examples/showcase/62_stegabin_shared_payload_path`.
+
+---
+
 ## 2026-03-06 (1): Bracket-Glob Sensitive Path Obfuscation Marker
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -66,6 +66,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `59_mcp_global_config_injection` | Repository/setup instructions write `mcpServers` entries directly into user-home assistant config files (`~/.cursor/mcp.json`, `~/.claude/settings.json`, etc.) with executable server commands | `EXF-013` |
 | `60_glob_cmd_shell_injection` | `glob` CLI command execution mode (`-c`/`--cmd`) on untrusted filenames, where shell metacharacters in file paths can trigger arbitrary command execution | `MAL-018` |
 | `61_bracket_glob_secret_path_bypass` | Bracket-glob obfuscation of sensitive file paths (for example `/etc/pass[w]d`, `/etc/shad[o]w`, `~/.ssh/id_r[s]a`) used to bypass literal denylist checks in shell/tool security guards | `EXF-014` |
+| `62_stegabin_shared_payload_path` | Campaign-linked shared npm malware loader payload path (`vendor/scrypt-js/version.js`) observed across recent StegaBin typosquat packages | `MAL-019` |
 
 ## Commands
 

--- a/examples/showcase/62_stegabin_shared_payload_path/install.js
+++ b/examples/showcase/62_stegabin_shared_payload_path/install.js
@@ -1,0 +1,3 @@
+// Simulated campaign artifact path referenced by loader code
+const payloadPath = "vendor/scrypt-js/version.js";
+console.log(`loading ${payloadPath}`);

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -76,3 +76,5 @@ skillscan scan examples/showcase/29_claude_sed_path_bypass --fail-on never
 ```
 60. `60_glob_cmd_shell_injection`: node-glob CLI `-c/--cmd` usage that can evaluate attacker-controlled filename metacharacters via shell execution context (`MAL-018`)
 61. `61_bracket_glob_secret_path_bypass`: bracket-glob obfuscation of sensitive file paths (`/etc/pass[w]d`, `/etc/shad[o]w`, `~/.ssh/id_r[s]a`) used to evade literal denylist checks (`EXF-014`)
+
+62. `62_stegabin_shared_payload_path`: campaign-linked shared malicious payload path (`vendor/scrypt-js/version.js`) seen across recent StegaBin typosquat npm packages (`MAL-019`)

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.06.1"
+version: "2026.03.06.2"
 
 static_rules:
   - id: MAL-001
@@ -375,6 +375,14 @@ static_rules:
     title: Tool auto-approve allowlist includes package-install command
     pattern: '(?is)(?:auto[- ]?approve|always\s+approve|allowed\s+commands|command\s+allowlist)[\s\S]{0,220}\b(?:npm\s+(?:install|i)|pnpm\s+install|yarn\s+install|bun\s+install)\b|\b(?:npm\s+(?:install|i)|pnpm\s+install|yarn\s+install|bun\s+install)\b[\s\S]{0,220}(?:auto[- ]?approve|always\s+approve|allowed\s+commands|command\s+allowlist)'
     mitigation: Do not auto-approve package-install commands in AI tool/extension settings. Require explicit user confirmation for install actions because lifecycle scripts can execute arbitrary code.
+
+  - id: MAL-019
+    category: malware_pattern
+    severity: high
+    confidence: 0.86
+    title: StegaBin npm shared payload path marker
+    pattern: '(?i)\bvendor/scrypt-js/version\.js\b'
+    mitigation: Treat references to `vendor/scrypt-js/version.js` in install/setup flows as high-risk campaign-linked malware markers. Remove package and investigate publisher provenance before installation.
 
   - id: EXF-014
     category: exfiltration

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -684,3 +684,13 @@ def test_new_patterns_2026_03_06() -> None:
     assert exf014.pattern.search("cat /etc/shad[o]w") is not None
     assert exf014.pattern.search("cat ~/.ssh/id_r[s]a") is not None
     assert exf014.pattern.search("cat /etc/passwd") is None
+
+
+def test_new_patterns_2026_03_06_patch2() -> None:
+    """Test StegaBin shared payload-path marker from recent npm campaign reporting."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal019 = next((r for r in compiled.static_rules if r.id == "MAL-019"), None)
+    assert mal019 is not None
+    assert mal019.pattern.search("vendor/scrypt-js/version.js") is not None
+    assert mal019.pattern.search("vendor/scrypt-js/version.jsx") is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -92,6 +92,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "MAL-018" for f in findings_60)
     findings_61 = _scan("examples/showcase/61_bracket_glob_secret_path_bypass").findings
     assert any(f.id == "EXF-014" for f in findings_61)
+    findings_62 = _scan("examples/showcase/62_stegabin_shared_payload_path").findings
+    assert any(f.id == "MAL-019" for f in findings_62)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- add MAL-019 static marker for campaign-linked StegaBin npm shared payload path (vendor/scrypt-js/version.js)
- bump default rules version to 2026.03.06.2
- add showcase fixture examples/showcase/62_stegabin_shared_payload_path
- add test coverage in tests/test_rules.py and tests/test_showcase_examples.py
- document update in PATTERN_UPDATES.md, examples/showcase/INDEX.md, and docs/EXAMPLES.md

## Validation
- .venv/bin/pytest -q
- .venv/bin/ruff check src tests

## Sources
- https://socket.dev/blog/stegabin-26-malicious-npm-packages-use-pastebin-steganography
- https://thehackernews.com/2026/03/north-korean-hackers-publish-26-npm.html