### PR TITLE
feat(ai): add non-blocking semantic assist mode

### DIFF
--- a/src/skillscan/analysis.py
+++ b/src/skillscan/analysis.py
@@ -608,6 +608,7 @@ def scan(
     ai_base_url: str | None = None,
     ai_timeout_seconds: int = 20,
     ai_required: bool = False,
+    ai_non_blocking: bool = False,
     ai_report_out: Path | None = None,
     clamav: bool = False,
     clamav_timeout_seconds: int = 30,
@@ -974,9 +975,11 @@ def scan(
             contribution = SEVERITY_SCORE[finding.severity] * weight
             score += contribution
             if finding.confidence >= policy.block_min_confidence:
+                if ai_non_blocking and finding.category == "ai_semantic_risk":
+                    continue
                 block_score += contribution
 
-        ai_critical_block = any(
+        ai_critical_block = (not ai_non_blocking) and any(
             f.category == "ai_semantic_risk"
             and f.severity == Severity.CRITICAL
             and f.confidence >= policy.ai_block_min_confidence

--- a/src/skillscan/cli.py
+++ b/src/skillscan/cli.py
@@ -97,6 +97,11 @@ def scan_cmd(
         "--ai-required/--ai-optional",
         help="Fail scan if AI assist is requested but unavailable",
     ),
+    ai_non_blocking: bool = typer.Option(
+        False,
+        "--ai-non-blocking/--ai-blocking",
+        help="Treat AI semantic findings as advisory only (cannot produce BLOCK verdict)",
+    ),
     ai_report_out: Path | None = typer.Option(
         None,
         "--ai-report-out",
@@ -187,6 +192,7 @@ def scan_cmd(
             ai_base_url=ai_base_url,
             ai_timeout_seconds=ai_timeout_seconds,
             ai_required=ai_required,
+            ai_non_blocking=ai_non_blocking,
             ai_report_out=ai_report_out,
             clamav=clamav,
             clamav_timeout_seconds=clamav_timeout_seconds,

--- a/tests/test_cli_more.py
+++ b/tests/test_cli_more.py
@@ -379,6 +379,49 @@ def test_scan_deprecated_extended_ai_alias(monkeypatch) -> None:
     assert calls["kwargs"]["ai_assist"] is True
 
 
+def test_scan_passes_ai_non_blocking_flag(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_scan(target, policy, policy_source, **kwargs):
+        calls["kwargs"] = kwargs
+        return __import__("skillscan.models", fromlist=["ScanReport"]).ScanReport.model_validate(
+            {
+                "metadata": {
+                    "scanner_version": "0.1.0",
+                    "target": str(target),
+                    "target_type": "directory",
+                    "ecosystem_hints": ["generic"],
+                    "rulepack_version": "x",
+                    "policy_profile": "strict",
+                    "policy_source": policy_source,
+                    "intel_sources": [],
+                },
+                "verdict": "allow",
+                "score": 0,
+                "findings": [],
+                "iocs": [],
+                "dependency_findings": [],
+                "capabilities": [],
+            }
+        )
+
+    monkeypatch.setattr("skillscan.cli.scan", fake_scan)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            "tests/fixtures/benign/basic_skill",
+            "--ai-assist",
+            "--ai-non-blocking",
+            "--fail-on",
+            "never",
+            "--no-auto-intel",
+        ],
+    )
+    assert result.exit_code == 0
+    assert calls["kwargs"]["ai_non_blocking"] is True
+
+
 def test_scan_passes_rulepack_channel(monkeypatch) -> None:
     calls: dict[str, object] = {}
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -188,6 +188,40 @@ def test_ai_critical_can_block(monkeypatch, tmp_path: Path) -> None:
     assert report.verdict == Verdict.BLOCK
 
 
+def test_ai_critical_non_blocking_mode_does_not_block(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "skill"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("benign wording", encoding="utf-8")
+
+    def fake_ai(*_args, **_kwargs):
+        return AIResult(
+            assessment=AIAssessment(
+                provider="openai",
+                model="gpt-4o-mini",
+                summary="critical risk",
+                findings_added=1,
+            ),
+            findings=[
+                Finding(
+                    id="AI-SEM-001",
+                    category="ai_semantic_risk",
+                    severity=Severity.CRITICAL,
+                    confidence=0.95,
+                    title="Critical semantic abuse",
+                    evidence_path=str(target / "SKILL.md"),
+                    snippet="x",
+                    mitigation="y",
+                )
+            ],
+            raw_response='{"summary":"x","risks":[]}',
+        )
+
+    monkeypatch.setattr("skillscan.analysis.run_ai_assist", fake_ai)
+    policy = load_builtin_policy("strict")
+    report = scan(target, policy, "builtin:strict", ai_assist=True, ai_non_blocking=True)
+    assert report.verdict != Verdict.BLOCK
+
+
 def test_npm_lifecycle_script_abuse_detected(tmp_path: Path) -> None:
     target = tmp_path / "pkg"
     target.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- add `--ai-non-blocking/--ai-blocking` CLI option
- wire `ai_non_blocking` through `scan(...)`
- in non-blocking mode, AI semantic findings remain advisory:
  - excluded from `block_score`
  - critical AI semantic auto-block path disabled
- keep existing behavior as default (`--ai-blocking` / `ai_non_blocking=False`)

## Validation
- `.venv/bin/ruff check src tests`
- `.venv/bin/pytest -q tests/test_scan.py::test_ai_critical_can_block tests/test_scan.py::test_ai_critical_non_blocking_mode_does_not_block tests/test_cli_more.py::test_scan_passes_ai_non_blocking_flag tests/test_cli_more.py::test_scan_passes_ai_flags`
