### PR TITLE
feat(report): confidence labels in compact, junit, and sarif outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ skillscan scan ./examples/suspicious_skill --format junit --out skillscan-junit.
 skillscan scan ./examples/suspicious_skill --format compact --fail-on never
 ```
 
+Confidence labels in findings are rendered as: `low`, `medium`, `high`, `critical`.
+
 Render saved report:
 
 ```bash

--- a/src/skillscan/compact.py
+++ b/src/skillscan/compact.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from skillscan.models import ScanReport
+from skillscan.models import ScanReport, confidence_label
 
 
 def report_to_compact_text(report: ScanReport) -> str:
@@ -10,8 +10,9 @@ def report_to_compact_text(report: ScanReport) -> str:
 
     for finding in report.findings[:10]:
         location = f"{finding.evidence_path}:{finding.line}" if finding.line else finding.evidence_path
+        clabel = confidence_label(finding.confidence).value
         lines.append(
-            f"- {finding.id} [{finding.severity.value}] {finding.title} @ {location}"
+            f"- {finding.id} [{finding.severity.value}/{clabel}] {finding.title} @ {location}"
         )
 
     if len(report.findings) > 10:

--- a/src/skillscan/junit.py
+++ b/src/skillscan/junit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
-from skillscan.models import ScanReport
+from skillscan.models import ScanReport, confidence_label
 
 
 def report_to_junit_xml(report: ScanReport) -> str:
@@ -34,12 +34,13 @@ def report_to_junit_xml(report: ScanReport) -> str:
                     "file": finding.evidence_path,
                 },
             )
+            clabel = confidence_label(finding.confidence).value
             failure = ET.SubElement(
                 case,
                 "failure",
                 {
-                    "message": finding.title,
-                    "type": finding.severity.value,
+                    "message": f"{finding.title} [{clabel}]",
+                    "type": f"{finding.severity.value}/{clabel}",
                 },
             )
             detail = finding.snippet.strip() if finding.snippet else finding.title

--- a/src/skillscan/models.py
+++ b/src/skillscan/models.py
@@ -35,21 +35,21 @@ class Finding(BaseModel):
 
 
 class ConfidenceLabel(StrEnum):
-    EXPERIMENTAL = "experimental"
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    CRITICAL = "critical"
 
 
 def confidence_label(confidence: float) -> ConfidenceLabel:
     """Map a 0.0-1.0 confidence score to a human-readable label."""
     if confidence < 0.5:
-        return ConfidenceLabel.EXPERIMENTAL
-    if confidence < 0.7:
         return ConfidenceLabel.LOW
-    if confidence < 0.85:
+    if confidence < 0.7:
         return ConfidenceLabel.MEDIUM
-    return ConfidenceLabel.HIGH
+    if confidence < 0.9:
+        return ConfidenceLabel.HIGH
+    return ConfidenceLabel.CRITICAL
 
 
 class IOC(BaseModel):

--- a/src/skillscan/sarif.py
+++ b/src/skillscan/sarif.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 
-from skillscan.models import ScanReport, Severity
+from skillscan.models import ScanReport, Severity, confidence_label
 
 
 def _level_from_severity(severity: Severity) -> str:
@@ -27,6 +27,7 @@ def report_to_sarif(report: ScanReport) -> dict:
                     "category": finding.category,
                     "defaultSeverity": finding.severity.value,
                     "confidence": finding.confidence,
+                    "confidenceLabel": confidence_label(finding.confidence).value,
                 },
             }
 
@@ -34,10 +35,11 @@ def report_to_sarif(report: ScanReport) -> dict:
         if finding.snippet:
             message = f"{message}: {finding.snippet.strip()}"
 
+        clabel = confidence_label(finding.confidence).value
         result: dict = {
             "ruleId": finding.id,
             "level": _level_from_severity(finding.severity),
-            "message": {"text": message},
+            "message": {"text": f"{message} [confidence={clabel}]"},
             "locations": [
                 {
                     "physicalLocation": {
@@ -50,6 +52,7 @@ def report_to_sarif(report: ScanReport) -> dict:
                 "category": finding.category,
                 "severity": finding.severity.value,
                 "confidence": finding.confidence,
+                "confidenceLabel": clabel,
                 "mitigation": finding.mitigation,
             },
         }

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -38,6 +38,7 @@ def test_compact_render() -> None:
     text = report_to_compact_text(report)
     assert "verdict=block" in text
     assert "ABU-001" in text
+    assert "[high/high]" in text
     assert "SKILL.md:2" in text
 
 

--- a/tests/test_junit.py
+++ b/tests/test_junit.py
@@ -49,6 +49,10 @@ def test_junit_with_findings() -> None:
     assert suite is not None
     assert suite.attrib["tests"] == "1"
     assert suite.attrib["failures"] == "1"
+    failure = root.find("testsuite/testcase/failure")
+    assert failure is not None
+    assert failure.attrib["type"] == "high/critical"
+    assert "[critical]" in failure.attrib["message"]
 
 
 def test_junit_without_findings() -> None:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -113,14 +113,14 @@ def test_recommended_actions_and_categories() -> None:
 
 
 def test_confidence_label_bands() -> None:
-    assert confidence_label(0.3) == ConfidenceLabel.EXPERIMENTAL
-    assert confidence_label(0.49) == ConfidenceLabel.EXPERIMENTAL
-    assert confidence_label(0.5) == ConfidenceLabel.LOW
-    assert confidence_label(0.69) == ConfidenceLabel.LOW
-    assert confidence_label(0.7) == ConfidenceLabel.MEDIUM
-    assert confidence_label(0.84) == ConfidenceLabel.MEDIUM
-    assert confidence_label(0.85) == ConfidenceLabel.HIGH
-    assert confidence_label(1.0) == ConfidenceLabel.HIGH
+    assert confidence_label(0.3) == ConfidenceLabel.LOW
+    assert confidence_label(0.49) == ConfidenceLabel.LOW
+    assert confidence_label(0.5) == ConfidenceLabel.MEDIUM
+    assert confidence_label(0.69) == ConfidenceLabel.MEDIUM
+    assert confidence_label(0.7) == ConfidenceLabel.HIGH
+    assert confidence_label(0.89) == ConfidenceLabel.HIGH
+    assert confidence_label(0.9) == ConfidenceLabel.CRITICAL
+    assert confidence_label(1.0) == ConfidenceLabel.CRITICAL
 
 
 def test_finding_narrative_includes_confidence() -> None:
@@ -135,7 +135,7 @@ def test_finding_narrative_includes_confidence() -> None:
         mitigation="remove it",
     )
     why, impact, next_action = _finding_narrative(finding)
-    assert "high confidence" in why
+    assert "critical confidence" in why
     assert "critical" in impact
 
 

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -50,6 +50,8 @@ def test_report_to_sarif_basic() -> None:
     result = sarif["runs"][0]["results"][0]
     assert result["ruleId"] == "MAL-001"
     assert result["level"] == "error"
+    assert result["properties"]["confidenceLabel"] == "critical"
+    assert "confidence=critical" in result["message"]["text"]
     assert result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"] == (
         "examples/showcase/01_download_execute/SKILL.md"
     )


### PR DESCRIPTION
## Summary
- update confidence label bands to: `low`, `medium`, `high`, `critical`
- propagate confidence labels into output formats:
  - compact lines include `[severity/confidenceLabel]`
  - JUnit failure type/message include confidence label
  - SARIF rule/result properties include `confidenceLabel`; message appends confidence label
- refresh tests for confidence band boundaries and output assertions
- document confidence labels in README

## Verification
- `ruff check src tests`
- `pytest -q tests/test_render.py tests/test_compact.py tests/test_junit.py tests/test_sarif.py`
- result: `12 passed`

## Tracking
- Issue: #53
