### PR TITLE
Fix line-length lint issue in benchmark builder script

### DIFF
--- a/scripts/build_prompt_injection_benchmark.py
+++ b/scripts/build_prompt_injection_benchmark.py
@@ -58,7 +58,9 @@ def _extract_text_label(record: dict) -> tuple[str, bool] | None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Build prompt-injection benchmark manifest from local datasets")
+    parser = argparse.ArgumentParser(
+        description="Build prompt-injection benchmark manifest from local datasets"
+    )
     parser.add_argument("--pint-root", type=Path, required=True)
     parser.add_argument("--openpi-root", type=Path, required=True)
     parser.add_argument("--out-dir", type=Path, default=Path("tests/benchmark/generated_prompt_injection"))


### PR DESCRIPTION
## Summary\n- wrap argparse description across lines to satisfy ruff E501\n- keep script behavior unchanged\n\n## Validation\n- ruff check .\n- pytest -q tests/test_benchmark_prompt_injection.py\n