### PR TITLE
chore(rules): add malware pattern updates 2026-03-14

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -72,6 +72,7 @@ SkillScan ships a full showcase in `examples/showcase` to demonstrate detection 
 | `65_dev_credential_harvest_list` | Combined references to multiple developer credential files (`~/.npmrc`, `~/.git-credentials`, `~/.config/gh/hosts.yml`) in one workflow/script, consistent with token-harvest staging observed in recent npm malware reporting | `EXF-015` |
 | `66_mcp_tool_name_collision_hijack` | MCP tool registration naming-collision guidance (`mcp_{service}_{tool}` / "tool name collision") and overwrite-hijack wording for trusted aliases (for example `tavily_extract`) | `ABU-005` |
 | `67_bash_param_expansion_smuggling` | Bash parameter-expansion command smuggling patterns (`${var@P}` and `${VAR:-$(cmd)}`) that can bypass read-only shell safety checks in AI CLI tooling | `MAL-022` |
+| `68_password_validation_harvest` | Cross-platform system password validation calls (`dscl -authonly`, PowerShell `ValidateCredentials`, `su -c true`) used in installer-style credential-harvest malware to verify stolen credentials | `MAL-023` |
 
 ## Commands
 

--- a/docs/RULE_UPDATES.md
+++ b/docs/RULE_UPDATES.md
@@ -1,5 +1,15 @@
 # Rule Updates
 
+## 2026-03-14
+
+- Added `MAL-023` (high): **Cross-platform password-harvest credential validation marker**.
+- Rationale: fresh reporting on the GhostClaw npm campaign showed installer-stage password collection validated directly through OS authentication commands (`dscl -authonly`, PowerShell `ValidateCredentials`, `su -c true`) before launching second-stage theft/RAT payloads.
+- Rule scope intentionally targets these explicit credential-validation call signatures to reduce false positives versus broad matching on auth-related text.
+
+Sources:
+- JFrog Security Research (2026-03-10), *GhostClaw Unmasked: A Malicious npm Package Impersonating OpenClaw to Steal Everything*: https://research.jfrog.com/post/ghostclaw-unmasked/
+- The Hacker News (2026-03-10), *Malicious npm Package Posing as OpenClaw Installer Deploys RAT, Steals macOS Credentials*: https://thehackernews.com/2026/03/malicious-npm-package-posing-as.html
+
 ## 2026-03-11
 
 - Added `ABU-005` (high): **MCP tool name-collision hijack marker**.

--- a/examples/showcase/68_password_validation_harvest/SKILL.md
+++ b/examples/showcase/68_password_validation_harvest/SKILL.md
@@ -1,0 +1,11 @@
+# Password Validation Harvest Showcase
+
+This sample demonstrates cross-platform credential validation code used by malware to verify user-supplied system passwords before second-stage theft:
+
+```js
+spawnSync("dscl", [".", "-authonly", username, password], { stdio: "pipe", timeout: 5000 });
+spawnSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", "$ctx.ValidateCredentials(username,password)"]);
+spawnSync("su", ["-c", "true", username], { input: password + "\n", stdio: "pipe" });
+```
+
+Legitimate installers should not collect raw passwords and validate them directly via OS auth CLIs.

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -84,3 +84,4 @@ skillscan scan examples/showcase/29_claude_sed_path_bypass --fail-on never
 
 66. `66_mcp_tool_name_collision_hijack`: MCP tool-name collision hijack wording (`mcp_{service}_{tool}`, overwrite of trusted tool aliases like `tavily_extract`) associated with CVE-2026-30856 (`ABU-005`)
 67. `67_bash_param_expansion_smuggling`: bash parameter-expansion command smuggling patterns (for example `${var@P}` and `${VAR:-$(cmd)}`) associated with CVE-2026-29783 / GHSA-g8r9-g2v8-jv6f (`MAL-022`)
+68. `68_password_validation_harvest`: cross-platform system password validation calls (`dscl -authonly`, PowerShell `ValidateCredentials`, `su -c true`) observed in installer-style credential-harvest malware (`MAL-023`)

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.03.11.2"
+version: "2026.03.14.1"
 
 static_rules:
   - id: MAL-001
@@ -432,6 +432,14 @@ static_rules:
     title: Bash parameter-expansion command smuggling marker
     pattern: '(?i)\$\{[^}\n]{0,140}@P[^}\n]*\}|\$\{[^}\n]{0,140}(?::?=|:-)\s*(?:\$\(|<\()[^}\n]{1,140}\)[^}\n]*\}'
     mitigation: Treat bash parameter expansions using `@P` or default/assignment operators with embedded command/process substitutions as unsafe in AI-suggested shell commands. Require explicit user review and block auto-execution.
+
+  - id: MAL-023
+    category: malware_pattern
+    severity: high
+    confidence: 0.85
+    title: Cross-platform password-harvest credential validation marker
+    pattern: '(?is)(?:spawnSync\(\s*["'']dscl["'']\s*,\s*\[\s*["'']\.["'']\s*,\s*["'']-authonly["'']|spawnSync\(\s*["'']powershell["'']\s*,\s*\[[^\]]{0,260}ValidateCredentials\(|spawnSync\(\s*["'']su["'']\s*,\s*\[\s*["'']-c["'']\s*,\s*["'']true["''])'
+    mitigation: Treat scripts that validate user-supplied passwords via `dscl -authonly`, `ValidateCredentials`, or `su -c true` as credential-harvest behavior. Remove password-collection flows and use OS-native delegated auth mechanisms.
 
 action_patterns:
   download: '\b(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm|download|git\s+clone|pip\s+install|npm\s+install|certutil\s+-urlcache|bitsadmin)\b|https?://'

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -834,3 +834,30 @@ def test_new_patterns_2026_03_11_patch2() -> None:
     assert mal022.pattern.search('echo ${a="$"}${b="$a(touch /tmp/pwned)"}${b@P}') is not None
     assert mal022.pattern.search('echo ${HOME:-$(whoami)}') is not None
     assert mal022.pattern.search('echo ${HOME:-/tmp}') is None
+
+
+def test_new_patterns_2026_03_14() -> None:
+    """Test cross-platform password-harvest credential validation marker."""
+    compiled = load_compiled_builtin_rulepack()
+
+    mal023 = next((r for r in compiled.static_rules if r.id == "MAL-023"), None)
+    assert mal023 is not None
+    assert (
+        mal023.pattern.search(
+            'spawnSync("dscl", [".", "-authonly", username, password], { stdio: "pipe" })'
+        )
+        is not None
+    )
+    assert (
+        mal023.pattern.search(
+            'spawnSync("powershell", ["-NoProfile", "-Command", "$ctx.ValidateCredentials(user,pass)"])'
+        )
+        is not None
+    )
+    assert (
+        mal023.pattern.search(
+            'spawnSync("su", ["-c", "true", username], { input: password + "\\n" })'
+        )
+        is not None
+    )
+    assert mal023.pattern.search('spawnSync("dscl", [".", "-list", "/Users"])') is None

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -105,6 +105,8 @@ def test_showcase_detection_rules() -> None:
     assert any(f.id == "ABU-005" for f in findings_66)
     findings_67 = _scan("examples/showcase/67_bash_param_expansion_smuggling").findings
     assert any(f.id == "MAL-022" for f in findings_67)
+    findings_68 = _scan("examples/showcase/68_password_validation_harvest").findings
+    assert any(f.id == "MAL-023" for f in findings_68)
 
 
 def test_showcase_policy_block_domain() -> None:


### PR DESCRIPTION
## Summary
- Added MAL-023: Cross-platform password-harvest credential validation marker
- Added showcase 68_password_validation_harvest demonstrating the pattern
- Updated docs/EXAMPLES.md, docs/RULE_UPDATES.md, examples/showcase/INDEX.md
- Added comprehensive tests for MAL-023
- Bumped rulepack version to 2026.03.14.1

## Validation
✅ .venv/bin/ruff check src tests - All checks passed
✅ .venv/bin/pytest -q - 174 passed in 102.87s

## Pattern Details
Detects scripts that validate user-supplied passwords via OS authentication commands:
- macOS: `dscl -authonly`
- Windows: PowerShell `ValidateCredentials`
- Linux: `su -c true`

## Sources
- JFrog Security Research (2026-03-10): https://research.jfrog.com/post/ghostclaw-unmasked/
- The Hacker News (2026-03-10): https://thehackernews.com/2026/03/malicious-npm-package-posing-as.html