### PR TITLE
chore: add pattern-update guardrails and CI gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+- What changed?
+- Why this is needed now?
+
+## Pattern Update Checklist (required for rules/default.yaml edits)
+- [ ] Worked on a feature branch (not `main`)
+- [ ] Added/updated rule IDs in `src/skillscan/data/rules/default.yaml`
+- [ ] Bumped rulepack version (`YYYY.MM.DD.N`)
+- [ ] Added/updated at least one showcase fixture under `examples/showcase/*`
+- [ ] Updated `examples/showcase/INDEX.md`
+- [ ] Updated `docs/EXAMPLES.md`
+- [ ] Added source-backed rationale in `docs/RULE_UPDATES.md` or `PATTERN_UPDATES.md`
+- [ ] Added tests in `tests/test_rules.py`
+- [ ] Added showcase assertion(s) in `tests/test_showcase_examples.py`
+
+## Validation
+- [ ] `ruff check src tests`
+- [ ] `pytest -q`
+
+## Sources
+- Link 1
+- Link 2

--- a/.github/workflows/pattern-update-guard.yml
+++ b/.github/workflows/pattern-update-guard.yml
@@ -1,0 +1,42 @@
+name: Pattern Update Guard
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - "chore/pattern-update-*"
+
+concurrency:
+  group: pattern-update-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pattern-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Validate pattern update hygiene
+        run: |
+          python scripts/validate_pattern_update.py
+
+      - name: Lint
+        run: |
+          ruff check src tests
+
+      - name: Tests
+        run: |
+          pytest -q

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owner
+* @kurtpayne
+
+# Security pattern/rule changes require owner review
+/src/skillscan/data/rules/* @kurtpayne
+/tests/test_rules.py @kurtpayne
+/tests/test_showcase_examples.py @kurtpayne
+/examples/showcase/* @kurtpayne
+/docs/RULE_UPDATES.md @kurtpayne
+/PATTERN_UPDATES.md @kurtpayne

--- a/docs/AUTOMATION_GUARDRAILS.md
+++ b/docs/AUTOMATION_GUARDRAILS.md
@@ -1,0 +1,49 @@
+# Automation Guardrails for Pattern Scout
+
+This document defines how automated pattern discovery/update runs must operate.
+
+## Goals
+- Keep `main` clean at all times.
+- Make updates deterministic, auditable, and reviewable.
+- Prevent partial/dirty updates when a run fails.
+
+## Required Workflow
+
+1. **Pre-flight checks**
+   - Ensure repo is on `main` and clean.
+   - Pull latest `origin/main`.
+   - If dirty: stash and exit (do not edit files).
+
+2. **Isolated branch execution**
+   - Create a branch: `chore/pattern-update-YYYYMMDD-<rand4hex>`.
+   - Perform all research, edits, tests, and commits on this branch.
+   - Never edit files directly on `main`.
+
+3. **Validation gate**
+   - Must pass:
+     - `ruff check src tests`
+     - `pytest -q`
+   - CI includes `Pattern Update Guard` workflow with additional policy checks.
+
+4. **PR-first integration**
+   - Push branch and open PR to `main`.
+   - Merge only after CI passes and review is complete.
+
+5. **Failure handling**
+   - If no update is warranted: delete temporary branch and return to `main`.
+   - If validation fails: return to `main`; keep failure output in summary.
+   - If PR creation fails: keep branch for manual recovery, but return to `main`.
+
+## Policy checks enforced in CI
+When `src/skillscan/data/rules/default.yaml` changes, CI requires:
+- version bump in `default.yaml`
+- at least one new rule ID in diff
+- tests updated (`tests/test_rules.py`, `tests/test_showcase_examples.py`)
+- showcase fixture updated under `examples/showcase/*`
+- docs index updates (`docs/EXAMPLES.md`, `examples/showcase/INDEX.md`)
+- rationale update (`docs/RULE_UPDATES.md` or `PATTERN_UPDATES.md`)
+
+## Operational notes
+- Keep updates small (prefer one coherent pattern set per PR).
+- Include source links in PR and changelog entries.
+- Prefer no-change exits over speculative/low-confidence rules.

--- a/scripts/validate_pattern_update.py
+++ b/scripts/validate_pattern_update.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Validate hygiene for automated pattern-update PRs.
+
+Checks only run when src/skillscan/data/rules/default.yaml is changed.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def sh(*args: str) -> str:
+    return subprocess.check_output(args, cwd=ROOT, text=True).strip()
+
+
+def changed_files(base: str = "origin/main") -> list[str]:
+    out = sh("git", "diff", "--name-only", f"{base}...HEAD")
+    return [line for line in out.splitlines() if line]
+
+
+def changed_file_content(path: str, base: str = "origin/main") -> str:
+    try:
+        return sh("git", "diff", f"{base}...HEAD", "--", path)
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def fail(msg: str) -> None:
+    print(f"❌ {msg}")
+    sys.exit(1)
+
+
+def main() -> int:
+    files = changed_files()
+    print(f"Changed files ({len(files)}):")
+    for f in files:
+        print(f" - {f}")
+
+    rules_path = "src/skillscan/data/rules/default.yaml"
+    if rules_path not in files:
+        print("ℹ️ default.yaml not changed; skipping pattern-update policy checks.")
+        return 0
+
+    required = {
+        "docs/EXAMPLES.md": "docs/EXAMPLES.md should be updated when rules change",
+        "examples/showcase/INDEX.md": "examples/showcase/INDEX.md should be updated",
+        "tests/test_rules.py": "tests/test_rules.py must include coverage for new rule(s)",
+        "tests/test_showcase_examples.py": (
+            "tests/test_showcase_examples.py should validate showcase detections"
+        ),
+    }
+    for path, msg in required.items():
+        if path not in files:
+            fail(msg)
+
+    if not any(p.startswith("examples/showcase/") and p != "examples/showcase/INDEX.md" for p in files):
+        fail("At least one showcase fixture under examples/showcase/* must be added/updated")
+
+    if not any(p in files for p in ("docs/RULE_UPDATES.md", "PATTERN_UPDATES.md")):
+        fail("Update docs/RULE_UPDATES.md or PATTERN_UPDATES.md with source-backed rationale")
+
+    diff = changed_file_content(rules_path)
+    if not re.search(r'^\+version:\s*"\d{4}\.\d{2}\.\d{2}\.\d+"', diff, flags=re.MULTILINE):
+        fail("default.yaml version must be bumped (expected YYYY.MM.DD.N)")
+
+    if not re.search(r"^\+\s*-\s+id:\s+[A-Z]{3}-\d{3}", diff, flags=re.MULTILINE):
+        fail("No new rule ID added in default.yaml diff")
+
+    print("✅ Pattern-update guard checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds automation guardrails to prevent the pattern-scout cron job from leaving `main` dirty.

### New files
- `scripts/validate_pattern_update.py` — pre-PR validation script (checks version bump, new rule ID, required file updates)
- `.github/workflows/pattern-update-guard.yml` — CI workflow that runs on pattern-update branches and PRs
- `.github/pull_request_template.md` — checklist for pattern update PRs
- `CODEOWNERS` — requires owner review on rules, tests, and showcase changes
- `docs/AUTOMATION_GUARDRAILS.md` — documents the required workflow for automated pattern updates

### Validation
- `ruff check src tests scripts` ✅
- `pytest -q` ✅ 174 passed

### Context
The pattern-scout cron job was repeatedly leaving uncommitted changes on `main`, blocking subsequent runs. This PR:
1. Documents the branch-isolation workflow
2. Adds CI enforcement so partial updates can't merge
3. Adds code ownership gates on security-sensitive paths