### PR TITLE
docs: post-release cleanup (SBOM guidance + v0.2.3 verification notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Default policy is `strict`.
 
 Release process and prerequisites: `docs/RELEASE_CHECKLIST.md` and `docs/RELEASE_ONBOARDING.md`.
 
+SBOMs:
+- Python CycloneDX SBOM is included in release artifacts (`sbom-python.cdx.json`).
+- Docker SPDX SBOM is uploaded as a GitHub Actions artifact in `Release Docker` runs (`sbom-docker.spdx.json`).
+
 ## Install
 
 ### Option A: convenience installer (curl|bash)
@@ -341,6 +345,7 @@ Shell script uninstall is also provided at `scripts/uninstall.sh`.
 - Distribution: `docs/DISTRIBUTION.md`
 - Release onboarding: `docs/RELEASE_ONBOARDING.md`
 - Release checklist: `docs/RELEASE_CHECKLIST.md`
+- Release verification (v0.2.3): `docs/RELEASE_VERIFICATION_0.2.3.md`
 
 ## License
 

--- a/docs/RELEASE_VERIFICATION_0.2.3.md
+++ b/docs/RELEASE_VERIFICATION_0.2.3.md
@@ -1,0 +1,27 @@
+# Release Verification — v0.2.3
+
+Date: 2026-03-16
+
+## Scope
+Post-release verification for package naming, runtime version alignment, Docker image behavior, and SBOM generation.
+
+## Results
+
+- PyPI package publish: `skillscan-security==0.2.3` ✅
+- Docker release publish: `kurtpayne/skillscan:v0.2.3` ✅
+- CLI version alignment:
+  - clean Python sandbox install reports `skillscan 0.2.3` ✅
+  - Docker image reports `skillscan 0.2.3` ✅
+- SBOM generation:
+  - Python CycloneDX SBOM generated (`sbom-python.cdx.json`) ✅
+  - Docker SPDX SBOM generated (`sbom-docker.spdx.json`) ✅
+
+## Notes
+
+- GitHub Release asset attach for Docker SBOM was disabled to avoid integration permission failures.
+- SBOM remains available as workflow artifact uploads.
+
+## Follow-up
+
+- Keep package name as `skillscan-security` while preserving CLI command as `skillscan`.
+- Continue release verification using `docs/RELEASE_CHECKLIST.md`.


### PR DESCRIPTION
## Summary
- add explicit README guidance on where to find Docker SBOM artifacts in GitHub Actions
- add release verification notes for v0.2.3 (PyPI, Docker, version alignment, SBOM outputs)

## Why
- improve post-release discoverability and reduce confusion around SBOM locations
- preserve an auditable verification record