### PR TITLE
feat: naming reset for first public release (v0.3.0)

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -45,7 +45,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/skillscan
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/skillscan-security
           tags: |
             type=ref,event=tag
             type=raw,value=latest
@@ -63,7 +63,7 @@ jobs:
       - name: Generate Docker image SBOM (SPDX JSON)
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ secrets.DOCKERHUB_USERNAME }}/skillscan:${{ github.ref_name }}
+          image: ${{ secrets.DOCKERHUB_USERNAME }}/skillscan-security:${{ github.ref_name }}
           format: spdx-json
           output-file: sbom-docker.spdx.json
           upload-release-assets: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ COPY src ./src
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir .
 
-ENTRYPOINT ["skillscan"]
+ENTRYPOINT ["skillscan-security"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Default policy is `strict`.
 
 - Source/dev install: supported now
 - PyPI install (`pip install skillscan-security`): supported via tag releases (`vX.Y.Z`)
-- CLI command remains `skillscan` for scanning/reporting flows
-- Docker image (`kurtpayne/skillscan`): supported via tag releases (`vX.Y.Z` + `latest`)
+- Primary CLI command: `skillscan-security` (alias `skillscan` retained)
+- Docker image (`kurtpayne/skillscan-security`): supported via tag releases (`vX.Y.Z` + `latest`)
 
 Release process and prerequisites: `docs/RELEASE_CHECKLIST.md` and `docs/RELEASE_ONBOARDING.md`.
 
@@ -68,7 +68,7 @@ pip install -e '.[dev]'
 ## Quick Start
 
 ```bash
-skillscan scan ./examples/suspicious_skill
+skillscan-security scan ./examples/suspicious_skill
 ```
 
 Scan directly from URL (including GitHub blob URLs):
@@ -218,7 +218,7 @@ AI Assist:
 - `skillscan intel status|list|add|remove|enable|disable|rebuild`
 - `skillscan intel sync [--force]`
 - `skillscan uninstall [--keep-data]`
-- `skillscan version`
+- `skillscan-security version`
 
 See full command docs: `docs/COMMANDS.md`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Make SkillScan the easiest and most trusted way to gate AI-skill/tool risk in lo
 - Add documented bind-mount scan examples.
 
 **Acceptance criteria**
-- `docker run ... skillscan scan /work` works on both arches.
+- `docker run ... skillscan-security scan /work` works on both arches.
 - Published tags map to app versions.
 - Startup + first scan docs validated in CI smoke job.
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -7,7 +7,7 @@ This document describes supported ways to install and operate SkillScan in local
 | Path | Best for | Command |
 |---|---|---|
 | PyPI | End users / CI | `pip install skillscan-security` |
-| Docker | Reproducible CI, isolated runtime | `docker run --rm -v "$PWD:/work" kurtpayne/skillscan:<tag> scan /work` |
+| Docker | Reproducible CI, isolated runtime | `docker run --rm -v "$PWD:/work" kurtpayne/skillscan-security:<tag> scan /work` |
 | Source/dev | Contributors | `pip install -e '.[dev]'` |
 | Convenience script | Quick local bootstrap | `curl -fsSL .../scripts/install.sh \| bash` |
 
@@ -21,7 +21,7 @@ This document describes supported ways to install and operate SkillScan in local
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e '.[dev]'
-skillscan version
+skillscan-security version
 ```
 
 Run a quick validation scan:
@@ -46,7 +46,7 @@ If using a fork/private location, set `SKILLSCAN_REPO_URL` first.
 
 ```bash
 pip install skillscan-security
-skillscan version
+skillscan-security version
 ```
 
 Published by: `kurtpayne` (PyPI trusted publishing from `kurtpayne/skillscan`).
@@ -62,7 +62,7 @@ pip install "skillscan-security==X.Y.Z"
 ## Docker Usage
 
 ```bash
-docker run --rm -v "$PWD:/work" kurtpayne/skillscan:<tag> scan /work --fail-on never
+docker run --rm -v "$PWD:/work" kurtpayne/skillscan-security:<tag> scan /work --fail-on never
 ```
 
 Expected tags:
@@ -79,14 +79,14 @@ Expected tags:
 git pull
 source .venv/bin/activate
 pip install -e '.[dev]'
-skillscan version
+skillscan-security version
 ```
 
 ### Future PyPI
 
 ```bash
 pip install --upgrade skillscan-security
-skillscan version
+skillscan-security version
 ```
 
 ### Future Docker

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -7,7 +7,7 @@ Use this checklist before creating a `vX.Y.Z` tag.
 - [ ] PyPI trusted publisher is configured for `kurtpayne/skillscan`
   - Workflow: `.github/workflows/release-pypi.yml`
   - Environment: `pypi`
-- [ ] Docker Hub repository exists: `kurtpayne/skillscan`
+- [ ] Docker Hub repository exists: `kurtpayne/skillscan-security`
 - [ ] GitHub secrets are set:
   - [ ] `DOCKERHUB_USERNAME`
   - [ ] `DOCKERHUB_TOKEN`
@@ -37,10 +37,10 @@ Use this checklist before creating a `vX.Y.Z` tag.
 
 - [ ] Verify PyPI install:
   - [ ] `pip install skillscan-security==X.Y.Z`
-  - [ ] `skillscan version`
+  - [ ] `skillscan-security version`
 - [ ] Verify Docker image:
-  - [ ] `docker pull kurtpayne/skillscan:vX.Y.Z`
-  - [ ] `docker run --rm kurtpayne/skillscan:vX.Y.Z version`
+  - [ ] `docker pull kurtpayne/skillscan-security:vX.Y.Z`
+  - [ ] `docker run --rm kurtpayne/skillscan-security:vX.Y.Z version`
 - [ ] Confirm release artifacts include:
   - [ ] wheel + sdist + SHA256SUMS
   - [ ] Python SBOM (`sbom-python.cdx.json`)

--- a/docs/RELEASE_ONBOARDING.md
+++ b/docs/RELEASE_ONBOARDING.md
@@ -5,12 +5,12 @@ Use this once to complete external account setup before first tagged release.
 ## Canonical publish targets
 
 - PyPI package: `skillscan-security`
-- Docker image: `kurtpayne/skillscan`
+- Docker image: `kurtpayne/skillscan-security`
 
 ## 1) Docker Hub
 
 1. Sign in to Docker Hub account `kurtpayne`.
-2. Create repository: `skillscan` (public).
+2. Create repository: `skillscan-security` (public).
 3. Create an access token with read/write scope.
 4. Add GitHub repo secrets:
    - `DOCKERHUB_USERNAME` = `kurtpayne`
@@ -37,7 +37,7 @@ Use this once to complete external account setup before first tagged release.
    - `Release Docker`
 5. Validate installs:
    - `pip install skillscan-security==X.Y.Z`
-   - `docker pull kurtpayne/skillscan:vX.Y.Z`
+   - `docker pull kurtpayne/skillscan-security:vX.Y.Z`
 6. Verify SBOM artifacts were generated and uploaded:
    - Python: `sbom-python.cdx.json`
    - Docker: `sbom-docker.spdx.json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillscan-security"
-version = "0.2.3"
+version = "0.3.0"
 description = "Standalone AI skill security scanner"
 readme = "README.md"
 authors = [{name = "SkillScan"}]
@@ -26,6 +26,7 @@ dev = [
 ]
 
 [project.scripts]
+skillscan-security = "skillscan.cli:app"
 skillscan = "skillscan.cli:app"
 
 [tool.setuptools]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,9 @@ git clone "${REPO_URL}" "${INSTALL_DIR}"
 python3 -m venv "${INSTALL_DIR}/.venv"
 "${INSTALL_DIR}/.venv/bin/pip" install --upgrade pip
 "${INSTALL_DIR}/.venv/bin/pip" install "${INSTALL_DIR}"
-ln -sf "${INSTALL_DIR}/.venv/bin/skillscan" "${BIN_DIR}/skillscan"
+ln -sf "${INSTALL_DIR}/.venv/bin/skillscan-security" "${BIN_DIR}/skillscan-security"
+ln -sf "${INSTALL_DIR}/.venv/bin/skillscan-security" "${BIN_DIR}/skillscan"
 
-echo "Installed SkillScan to ${BIN_DIR}/skillscan"
+echo "Installed SkillScan Security to ${BIN_DIR}/skillscan-security"
+echo "Alias created at ${BIN_DIR}/skillscan"
 echo "Ensure ${BIN_DIR} is in your PATH"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,10 +7,11 @@ if [[ "${1:-}" == "--keep-data" ]]; then
 fi
 
 BIN_PATH="${HOME}/.local/bin/skillscan"
+BIN_PATH_CANONICAL="${HOME}/.local/bin/skillscan-security"
 RUNTIME_DIR="${HOME}/.skillscan/runtime"
 DATA_DIR="${HOME}/.skillscan"
 
-rm -f "${BIN_PATH}"
+rm -f "${BIN_PATH}" "${BIN_PATH_CANONICAL}"
 rm -rf "${RUNTIME_DIR}"
 
 if [[ "${KEEP_DATA}" == "false" ]]; then

--- a/src/skillscan/cli.py
+++ b/src/skillscan/cli.py
@@ -73,7 +73,7 @@ def _build_delta_payload(baseline_data: dict, current_data: dict, baseline_label
 
 @app.command("version")
 def version() -> None:
-    console.print(f"skillscan {__version__}")
+    console.print(f"skillscan-security {__version__}")
 
 
 @app.command("scan")

--- a/tests/test_cli_more.py
+++ b/tests/test_cli_more.py
@@ -15,7 +15,7 @@ runner = CliRunner()
 def test_version_and_policy_commands() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
-    assert "skillscan" in result.stdout
+    assert "skillscan-security" in result.stdout
 
     show = runner.invoke(app, ["policy", "show-default", "--profile", "strict"])
     assert show.exit_code == 0


### PR DESCRIPTION
## Summary
- canonicalize user-facing naming to 
- keep  as a compatibility alias command
- switch Docker publish target to 
- set release version to 

## Included
- pyproject scripts:  +  alias
- CLI version output updated to 
- installer/uninstaller updated for canonical + alias binaries
- release docs/checklists/onboarding updated for new Docker repo and command usage
- release-docker workflow image target updated

## Validation
- targeted CLI version tests pass
- ruff lint pass