### PR TITLE
chore(validation): add local validation wrapper and guardrail updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint type test check demo
+.PHONY: setup lint type test check demo validate-local
 
 setup:
 	python3 -m venv .venv
@@ -17,3 +17,6 @@ check: lint type test
 
 demo:
 	.venv/bin/skillscan scan examples/suspicious_skill --fail-on never
+
+validate-local:
+	TIMEOUT_SECONDS=900 ./scripts/run_local_validation.sh

--- a/docs/AUTOMATION_GUARDRAILS.md
+++ b/docs/AUTOMATION_GUARDRAILS.md
@@ -20,9 +20,11 @@ This document defines how automated pattern discovery/update runs must operate.
    - Never edit files directly on `main`.
 
 3. **Validation gate**
-   - Must pass:
-     - `ruff check src tests`
-     - `pytest -q`
+   - Must pass (repo venv only):
+     - `.venv/bin/ruff check src tests`
+     - `.venv/bin/pytest -q`
+   - Recommended local wrapper for deterministic runs:
+     - `TIMEOUT_SECONDS=900 ./scripts/run_local_validation.sh`
    - CI includes `Pattern Update Guard` workflow with additional policy checks.
 
 4. **PR-first integration**

--- a/scripts/run_local_validation.sh
+++ b/scripts/run_local_validation.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTEST_BIN=".venv/bin/pytest"
+RUFF_BIN=".venv/bin/ruff"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-900}"
+TARGETED_TIMEOUT_SECONDS="${TARGETED_TIMEOUT_SECONDS:-240}"
+
+if [[ ! -x "$PYTEST_BIN" || ! -x "$RUFF_BIN" ]]; then
+  echo "ERROR: missing repo venv tools. Run 'make setup' in $ROOT_DIR" >&2
+  exit 2
+fi
+
+echo "[validate] root=$ROOT_DIR"
+echo "[validate] timeout=${TIMEOUT_SECONDS}s"
+
+echo "[1/3] ruff"
+"$RUFF_BIN" check src tests
+
+echo "[2/3] targeted tests"
+"$PYTEST_BIN" -q tests/test_rules.py::test_new_patterns_2026_03_15
+"$PYTEST_BIN" -q tests/test_showcase_examples.py::test_showcase_detection_rules
+
+echo "[3/3] full suite (timeout)"
+set +e
+timeout "${TIMEOUT_SECONDS}s" "$PYTEST_BIN" -q
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  echo "[validate] full suite passed"
+  exit 0
+fi
+
+if [[ $rc -eq 124 ]]; then
+  echo "[validate] full suite timed out after ${TIMEOUT_SECONDS}s" >&2
+  exit 124
+fi
+
+echo "[validate] full suite failed with exit code $rc" >&2
+exit "$rc"


### PR DESCRIPTION
## Summary\n- add scripts/run_local_validation.sh wrapper for deterministic local validation\n- add Makefile target: validate-local\n- update docs/AUTOMATION_GUARDRAILS.md to use repo venv binaries and wrapper command\n\n## Validation\n- TIMEOUT_SECONDS=600 ./scripts/run_local_validation.sh\n  - ruff: pass\n  - targeted tests: pass\n  - full suite: pass\n\nThis is refactor/validation plumbing only.