### PR TITLE
chore: post-mortem tech debt (P4/P5/P6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12', '3.13']
+    env:
+      # P5: Prevent user-local ~/.skillscan/rules/ from influencing test results.
+      # Tests must pass against the bundled rulepack only (post-mortem action item).
+      SKILLSCAN_NO_USER_RULES: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/src/skillscan/rules.py
+++ b/src/skillscan/rules.py
@@ -169,7 +169,14 @@ def load_builtin_rulepack(channel: str = "stable") -> RulePack:
     for f in files:
         log.debug("  bundled: %s", f)
 
-    rulepacks = [_load_yaml_rule_file(p.read_text(encoding="utf-8")) for p in files]
+    # Build a name -> version map for bundled files so we can version-gate user-local files.
+    bundled_versions: dict[str, str] = {}
+    bundled_rulepacks: list[RulePack] = []
+    for p in files:
+        rp = _load_yaml_rule_file(p.read_text(encoding="utf-8"))
+        bundled_versions[p.name] = rp.version
+        bundled_rulepacks.append(rp)
+    rulepacks = bundled_rulepacks
 
     # Merge user-local rules on top of bundled rules (signature-as-data layer).
     # User-local rules are downloaded by `skillscan rules sync` and live in
@@ -194,10 +201,24 @@ def load_builtin_rulepack(channel: str = "stable") -> RulePack:
                         len(user_files),
                         user_dir,
                     )
+                    accepted: list[RulePack] = []
                     for f in user_files:
-                        log.debug("  user-local: %s", f)
-                    user_rulepacks = [_load_yaml_rule_file(p.read_text(encoding="utf-8")) for p in user_files]
-                    rulepacks = rulepacks + user_rulepacks
+                        user_rp = _load_yaml_rule_file(f.read_text(encoding="utf-8"))
+                        bundled_ver = bundled_versions.get(f.name)
+                        # P6: Skip user-local files that are older than their bundled counterpart.
+                        # Version strings use YYYY.MM.DD.N format and sort lexicographically.
+                        if bundled_ver is not None and user_rp.version < bundled_ver:
+                            log.warning(
+                                "[rules] skipping stale user-local rule file %s "
+                                "(user=%s < bundled=%s); run 'skillscan rules sync' to update",
+                                f.name,
+                                user_rp.version,
+                                bundled_ver,
+                            )
+                        else:
+                            log.debug("  user-local: %s (version=%s)", f, user_rp.version)
+                            accepted.append(user_rp)
+                    rulepacks = rulepacks + accepted
                 else:
                     log.debug(
                         "[rules] user-local rules dir exists (%s) but no matching YAML for channel=%s",
@@ -210,12 +231,16 @@ def load_builtin_rulepack(channel: str = "stable") -> RulePack:
             pass
 
     merged = _merge_rulepacks(rulepacks)
-    log.debug(
-        "[rules] merged rulepack ready: version=%s  static=%d  chain=%d  action_patterns=%d",
+    # P4: Log rulepack provenance at INFO on every cold load so developers see it
+    # without needing --debug.  The lru_cache on load_compiled_builtin_rulepack means
+    # this fires once per process (or once per test when the cache is cleared by conftest).
+    log.info(
+        "[rules] rulepack loaded: version=%s  static=%d  chain=%d  action_patterns=%d  channel=%s",
         merged.version,
         len(merged.static_rules),
         len(merged.chain_rules),
         len(merged.action_patterns),
+        channel,
     )
     return merged
 

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -69,6 +69,9 @@ def custom_rules_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     import skillscan.rules_sync as rules_sync_mod
 
     monkeypatch.setattr(rules_sync_mod, "USER_RULES_DIR", rules_dir)
+    # Ensure SKILLSCAN_NO_USER_RULES is not set so the user-local rules dir is
+    # consulted even when running under CI (which sets this env var globally).
+    monkeypatch.delenv("SKILLSCAN_NO_USER_RULES", raising=False)
 
     # Clear the LRU cache so the patched directory is used on the next call
     load_compiled_builtin_rulepack.cache_clear()


### PR DESCRIPTION
## Summary

Addresses three action items from `docs/postmortem-2026-03-27-ci-failures.md`.

### P5 — Isolate test HOME
Set `SKILLSCAN_NO_USER_RULES=1` in the CI `test` job `env` block. Tests now always run against the bundled rulepack only, regardless of what is in `~/.skillscan/rules/` on the runner. Eliminates the entire class of "works on my machine because my local rules are stale" failures.

### P4 — INFO-level rule provenance log
Replaced the DEBUG-only merged rulepack log in `load_builtin_rulepack()` with an INFO-level log. Fires once per cold cache load (the `lru_cache` on `load_compiled_builtin_rulepack` means it's effectively once per process). Includes version string, static/chain/action_pattern counts, and channel. No `--debug` flag required.

### P6 — Version-gate user-local rules
`load_builtin_rulepack()` now checks each user-local file against its bundled counterpart by filename. If the user-local version string is older (lexicographic comparison on `YYYY.MM.DD.N` format), emits `WARNING` and skips the file rather than merging it. Prevents a stale `skillscan rules sync` from silently downgrading detection capability. Files with no bundled counterpart (custom enterprise rules) are always accepted.

### test_custom_rules fixture fix
Added `monkeypatch.delenv('SKILLSCAN_NO_USER_RULES', raising=False)` to the `custom_rules_dir` fixture. Without this, the P5 CI env var would suppress the user-local rules dir that the fixture sets up, causing the custom rules tests to fail in CI.

### Pattern-update skill gate (SKILL.md)
Hardened step 8 with a mandatory copy-paste bash block that must exit 0 before `gh pr create` is called. References the post-mortem doc.

## Testing
- `ruff check`, `ruff format --check`, `mypy src` all pass
- `SKILLSCAN_NO_USER_RULES=1 pytest tests/test_custom_rules.py tests/test_rules.py tests/test_showcase_examples.py tests/test_ml_detector.py` — 93 passed, 0 failed