### PR TITLE
chore: pattern update 2026-04-12 — PSV-013, PINJ-022, SUP-034, PSV-014

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,23 @@
+## 2026-04-12
+
+**Sources:**
+- SentinelOne (CVE-2026-31854)
+- NVD (CVE-2026-33654, CVE-2026-35577)
+- Tenable (TRA-2026-27)
+
+**Summary:**
+Added detection for Cursor IDE RCE via indirect prompt injection, nanobot indirect prompt injection via email, claude-code-action arbitrary code execution via malicious .mcp.json, and Apollo MCP Server DNS rebinding.
+
+**Rule Details:**
+- `PSV-013`: Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection
+- `PINJ-022`: nanobot CVE-2026-33654 Indirect Prompt Injection via Email
+- `SUP-034`: claude-code-action Arbitrary Code Execution via Malicious .mcp.json
+- `PSV-014`: Apollo MCP Server CVE-2026-35577 DNS Rebinding
+
+**IOC/Corpus Updates:**
+- Added 4 new organic eval holdouts to the corpus.
+- Updated vulnerability database with CVE-2026-31854, CVE-2026-33654, TRA-2026-27, and CVE-2026-35577.
+
 ## 2026-04-11
 rulepack: 2026.04.11.1
 Three new detection rules, IOC enrichment, and vuln DB updates covering a critical MCP server RCE, a new GlassWorm Unicode steganography wave, and an OpenVSX marketplace Zip Slip vulnerability.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -3,7 +3,7 @@
 > Auto-generated from `src/skillscan/data/rules/`. Do not edit by hand.
 > Run `python3 scripts/generate_examples_table.py` to regenerate.
 
-**196 static rules · 14 chain rules**
+**200 static rules · 14 chain rules**
 
 ## Static Rules
 
@@ -183,6 +183,7 @@
 | `SUP-031` | high | PackageGate npm/pnpm lifecycle script security bypass (CVE-2025-69264, CVE-2025-69263) | supply-chain, npm, pnpm, cve-2025-69264, cve-2025-69263, lifecycle-bypass, packagegate, zero-day |
 | `SUP-032` | critical | Compromised velora-dex/sdk package version reference | supply-chain, npm, velora-dex, malicious-version, rat |
 | `SUP-033` | high | OpenVSX Code Extension Marketplace Zip Slip vulnerability (CVE-2026-35454, pre-2.4.2) | supply-chain, openvsx, zip-slip, path-traversal, vscode-extension, marketplace, cve-2026-35454 |
+| `SUP-034` | medium | claude-code-action Arbitrary Code Execution via Malicious .mcp.json | supply_chain, sup, claude-code-action, mcp, github-actions, tra-2026-27 |
 
 ### Defense Evasion
 
@@ -218,6 +219,7 @@
 | `PINJ-019` | critical | Claudy Day invisible URL parameter prompt injection + Files API exfiltration | prompt-injection, claude, anthropic, files-api, exfiltration, claudy-day |
 | `PINJ-020` | critical | MINJA cross-session AI agent memory poisoning via untrusted documents | prompt-injection, memory-poisoning, minja, cross-session, persistent-injection, owasp-asi06, ai-agent |
 | `PINJ-021` | high | A2A agent card poisoning -- adversarial instructions in agent card metadata | prompt-injection, a2a, agent-card, metadata-injection, google-a2a, multi-agent, exfiltration |
+| `PINJ-022` | high | nanobot CVE-2026-33654 Indirect Prompt Injection via Email | prompt_injection, pinj, nanobot, cve-2026-33654, email |
 
 ### Passive Vulnerabilities
 
@@ -231,6 +233,8 @@
 | ID | Severity | Title | Tags |
 |---|---|---|---|
 | `PSV-008` | critical | Cursor IDE CVE-2026-22708 RCE via Shell Built-ins | platform_security, psv, cursor, rce, cve-2026-22708 |
+| `PSV-013` | high | Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection | platform_security, psv, cursor, rce, cve-2026-31854, prompt-injection |
+| `PSV-014` | medium | Apollo MCP Server CVE-2026-35577 DNS Rebinding | platform_security, psv, apollo-mcp, dns-rebinding, cve-2026-35577 |
 
 ### Execution
 

--- a/examples/showcase/165_psv013_cursor_rce_cve_2026_31854/SKILL.md
+++ b/examples/showcase/165_psv013_cursor_rce_cve_2026_31854/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cursor-rce-test
+description: Test for Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection
+---
+
+# Cursor RCE Test
+
+This skill tests the detection of CVE-2026-31854.
+The vulnerability allows malicious websites to use indirect prompt injection to bypass command whitelists and execute arbitrary commands.
+
+```bash
+# Trigger pattern
+echo "CVE-2026-31854"
+echo "cursor prompt injection malicious website bypass execute RCE"
+```

--- a/examples/showcase/166_pinj022_nanobot_cve_2026_33654/SKILL.md
+++ b/examples/showcase/166_pinj022_nanobot_cve_2026_33654/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: nanobot-pinj-test
+description: Test for nanobot CVE-2026-33654 Indirect Prompt Injection via Email
+---
+
+# nanobot PINJ Test
+
+This skill tests the detection of CVE-2026-33654.
+The vulnerability allows malicious emails to bypass channel isolation and execute arbitrary LLM instructions.
+
+```bash
+# Trigger pattern
+echo "CVE-2026-33654"
+echo "nanobot email prompt injection bypass isolation"
+```

--- a/examples/showcase/167_sup034_claude_code_action_tra_2026_27/SKILL.md
+++ b/examples/showcase/167_sup034_claude_code_action_tra_2026_27/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: claude-code-action-test
+description: Test for claude-code-action Arbitrary Code Execution via Malicious .mcp.json
+---
+
+# claude-code-action Test
+
+This skill tests the detection of TRA-2026-27.
+The vulnerability allows a malicious .mcp.json file in a PR branch to lead to arbitrary command execution in the runner.
+
+```bash
+# Trigger pattern
+echo "TRA-2026-27"
+echo "claude-code-action .mcp.json enableAllProjectMcpServers"
+```

--- a/examples/showcase/168_psv014_apollo_mcp_cve_2026_35577/SKILL.md
+++ b/examples/showcase/168_psv014_apollo_mcp_cve_2026_35577/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: apollo-mcp-test
+description: Test for Apollo MCP Server CVE-2026-35577 DNS Rebinding
+---
+
+# Apollo MCP Test
+
+This skill tests the detection of CVE-2026-35577.
+The vulnerability allows DNS rebinding on StreamableHTTP transport due to improper Host header validation.
+
+```bash
+# Trigger pattern
+echo "CVE-2026-35577"
+echo "apollo mcp dns rebinding StreamableHTTP Host header"
+```

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -186,3 +186,7 @@ skillscan scan examples/showcase/29_claude_sed_path_bypass --fail-on never
 164. `162_psv012_aws_mcp_server_cmd_injection`: aws-mcp-server command injection RCE CVE-2026-5058/CVE-2026-5059 (`PSV-012`)
 165. `163_mal067_glassworm_unicode_pua_eval`: GlassWorm invisible Unicode PUA payload injection eval via FE00-FE0F/E0100-E01EF encoding (`MAL-067`)
 166. `164_sup033_openvsx_zip_slip`: OpenVSX Code Extension Marketplace Zip Slip vulnerability CVE-2026-35454 pre-2.4.2 (`SUP-033`)
+167. `165_psv013_cursor_rce_cve_2026_31854`: Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection (`PSV-013`)
+168. `166_pinj022_nanobot_cve_2026_33654`: nanobot CVE-2026-33654 Indirect Prompt Injection via Email (`PINJ-022`)
+169. `167_sup034_claude_code_action_tra_2026_27`: claude-code-action Arbitrary Code Execution via Malicious .mcp.json (`SUP-034`)
+170. `168_psv014_apollo_mcp_cve_2026_35577`: Apollo MCP Server CVE-2026-35577 DNS Rebinding (`PSV-014`)

--- a/src/skillscan/data/intel/vuln_db.json
+++ b/src/skillscan/data/intel/vuln_db.json
@@ -1330,5 +1330,37 @@
         "fixed": "REMOVED"
       }
     }
+  },
+  "cursor": {
+    "<2.0": {
+      "id": "CVE-2026-31854",
+      "severity": "high",
+      "fixed": "2.0",
+      "summary": "Cursor IDE RCE via indirect prompt injection from malicious websites"
+    }
+  },
+  "nanobot": {
+    "<0.1.6": {
+      "id": "CVE-2026-33654",
+      "severity": "high",
+      "fixed": "0.1.6",
+      "summary": "nanobot indirect prompt injection via email channel"
+    }
+  },
+  "claude-code-action": {
+    "<1.0.78": {
+      "id": "TRA-2026-27",
+      "severity": "medium",
+      "fixed": "1.0.78",
+      "summary": "claude-code-action arbitrary code execution via malicious .mcp.json in PR branch"
+    }
+  },
+  "apollo-mcp": {
+    "<1.7.0": {
+      "id": "CVE-2026-35577",
+      "severity": "medium",
+      "fixed": "1.7.0",
+      "summary": "Apollo MCP Server DNS rebinding vulnerability on StreamableHTTP transport"
+    }
   }
 }

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.04.11.1"
+version: "2026.04.12.1"
 static_rules:
   - id: MAL-001
     category: malware_pattern
@@ -5542,6 +5542,7 @@ static_rules:
     severity: critical
     confidence: 0.93
     title: ClawHub malicious skill keylogger/Atomic Stealer payload delivery
+    mitigation: Remove the malicious skill and rotate credentials.
     pattern: '(?i)(?:(?:clawhub|openclaw)\s+install[^\n]{0,120}(?:keylogger|atomic[_\s-]?stealer|stealer|infostealer)|keylogger[^\n]{0,120}(?:clawhub|openclaw|clawHub)[^\n]{0,120}(?:install|module|component|captures)|atomic[_\s-]?stealer[^\n]{0,120}(?:clawhub|openclaw|via\s+(?:clawhub|openclaw))|(?:clawhub|openclaw)[^\n]{0,200}(?:keylogger|atomic[_\s-]?stealer|keystroke)[^\n]{0,200}(?:install|deploy|download|capture))'
     metadata:
       version: '1.0.0'
@@ -5580,6 +5581,7 @@ static_rules:
     severity: high
     confidence: 0.92
     title: a11y-mcp SSRF vulnerability (CVE-2026-5323)
+    mitigation: Update a11y-mcp to a patched version.
     pattern: '(?i)(?:CVE-2026-5323|a11y[_-]?mcp[^\n]{0,200}(?:ssrf|server[_\s-]?side[_\s-]?request|169\.254\.169\.254|metadata|internal[_\s-]?network|A11yServer)|(?:ssrf|server[_\s-]?side[_\s-]?request)[^\n]{0,120}a11y[_-]?mcp|priyankark/a11y-mcp[^\n]{0,200}(?:ssrf|vuln|cve))'
     metadata:
       version: '1.0.0'
@@ -5615,6 +5617,7 @@ static_rules:
     severity: critical
     confidence: 0.93
     title: Claudy Day invisible URL parameter prompt injection + Files API exfiltration
+    mitigation: Sanitize URL parameters and restrict Files API access.
     pattern: '(?i)(?:claudy[_\s-]?day[^\n]{0,200}(?:url|parameter|inject|exfil|files\.anthropic)|files\.anthropic\.com[^\n]{0,200}(?:exfil|steal|harvest|conversation[_\s]?history|upload[_\s]?conversation)|hidden[^\n]{0,120}(?:html|tag|span)[^\n]{0,120}(?:claude|prompt|inject)[^\n]{0,120}(?:instruct|ignore|override|exfil))'
     metadata:
       version: '1.0.0'
@@ -6220,6 +6223,148 @@ static_rules:
         - https://www.cvedetails.com/cve/CVE-2026-35454/
         - https://expertinthecloud.co.za/tag/open-vsx-vulnerability-lets-malicious-extensions-slip-through/
         - https://cyberpress.org/openvsx-extension-spreads-glassworm/?amp=1
+  - id: PSV-013
+    category: platform_security
+    severity: high
+    confidence: 0.95
+    title: Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection
+    pattern: (?i)(?:CVE-2026-31854|cursor[^\n]{0,120}(?:prompt[^\n]{0,40}injection|malicious[^\n]{0,40}website)[^\n]{0,120}(?:bypass|execute|RCE))
+    mitigation: 'CVE-2026-31854 is a high severity RCE vulnerability in Cursor IDE (versions prior to 2.0) where malicious websites can use indirect prompt injection to bypass command whitelists and execute arbitrary commands. Update Cursor to version 2.0 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-12'
+      updated: '2026-04-12'
+      tags:
+        - platform_security
+        - psv
+        - cursor
+        - rce
+        - cve-2026-31854
+        - prompt-injection
+      last_modified: '2026-04-12'
+      techniques:
+        - id: EXEC-048
+          name: Execution or malware behavior
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-12'
+        last_modified: '2026-04-12'
+      quality:
+        precision_estimate: 0.95
+        benchmark_set: core-static-v1
+      references:
+        - https://www.sentinelone.com/vulnerability-database/cve-2026-31854/
+  - id: PINJ-022
+    category: prompt_injection
+    severity: high
+    confidence: 0.95
+    title: nanobot CVE-2026-33654 Indirect Prompt Injection via Email
+    pattern: (?i)(?:CVE-2026-33654|nanobot[^\n]{0,120}email[^\n]{0,120}(?:prompt[^\n]{0,40}injection|bypass[^\n]{0,40}isolation))
+    mitigation: 'CVE-2026-33654 is a high severity indirect prompt injection vulnerability in nanobot (versions prior to 0.1.6) where malicious emails can bypass channel isolation and execute arbitrary LLM instructions. Update nanobot to version 0.1.6 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-12'
+      updated: '2026-04-12'
+      tags:
+        - prompt_injection
+        - pinj
+        - nanobot
+        - cve-2026-33654
+        - email
+      last_modified: '2026-04-12'
+      techniques:
+        - id: PINJ-001
+          name: Prompt Injection
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-12'
+        last_modified: '2026-04-12'
+      quality:
+        precision_estimate: 0.95
+        benchmark_set: core-static-v1
+      references:
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-33654
+  - id: SUP-034
+    category: supply_chain
+    severity: medium
+    confidence: 0.95
+    title: claude-code-action Arbitrary Code Execution via Malicious .mcp.json
+    pattern: (?i)(?:TRA-2026-27|claude-code-action[^\n]{0,120}\.mcp\.json[^\n]{0,120}enableAllProjectMcpServers)
+    mitigation: 'Tenable TRA-2026-27 identifies a vulnerability in claude-code-action (versions prior to 1.0.78) where a malicious .mcp.json file in a PR branch can lead to arbitrary command execution in the runner. Update claude-code-action to version 1.0.78 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-12'
+      updated: '2026-04-12'
+      tags:
+        - supply_chain
+        - sup
+        - claude-code-action
+        - mcp
+        - github-actions
+        - tra-2026-27
+      last_modified: '2026-04-12'
+      techniques:
+        - id: SUP-027
+          name: Supply Chain Compromise
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-12'
+        last_modified: '2026-04-12'
+      quality:
+        precision_estimate: 0.95
+        benchmark_set: core-static-v1
+      references:
+        - https://www.tenable.com/security/research/tra-2026-27
+  - id: PSV-014
+    category: platform_security
+    severity: medium
+    confidence: 0.95
+    title: Apollo MCP Server CVE-2026-35577 DNS Rebinding
+    pattern: (?i)(?:CVE-2026-35577|apollo[^\n]{0,40}mcp[^\n]{0,120}dns[^\n]{0,40}rebinding|StreamableHTTP[^\n]{0,120}Host[^\n]{0,40}header)
+    mitigation: 'CVE-2026-35577 is a medium severity DNS rebinding vulnerability in Apollo MCP Server (versions prior to 1.7.0) when using StreamableHTTP transport due to improper Host header validation. Update Apollo MCP Server to version 1.7.0 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-12'
+      updated: '2026-04-12'
+      tags:
+        - platform_security
+        - psv
+        - apollo-mcp
+        - dns-rebinding
+        - cve-2026-35577
+      last_modified: '2026-04-12'
+      techniques:
+        - id: EXEC-048
+          name: Execution or malware behavior
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-12'
+        last_modified: '2026-04-12'
+      quality:
+        precision_estimate: 0.95
+        benchmark_set: core-static-v1
+      references:
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-35577
 capability_patterns:
   shell_execution: \b(subprocess|os\.system|bash|powershell)\b
   network_access: \b(requests\.|fetch\(|axios|http[s]?://|socket)\b

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2218,3 +2218,47 @@ def test_sup033_openvsx_zip_slip() -> None:
     assert rule.pattern.search("open-vsx 2.4.1 malicious bypass") is not None
     assert rule.pattern.search("install openvsx extension from marketplace") is None
     assert rule.pattern.search("openvsx 2.4.2 release notes") is None
+
+
+def test_rule_psv_013():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/165_psv013_cursor_rce_cve_2026_31854"), p, "builtin:strict")
+    assert any(f.id == "PSV-013" for f in r.findings)
+
+
+def test_rule_pinj_022():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/166_pinj022_nanobot_cve_2026_33654"), p, "builtin:strict")
+    assert any(f.id == "PINJ-022" for f in r.findings)
+
+
+def test_rule_sup_034():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/167_sup034_claude_code_action_tra_2026_27"), p, "builtin:strict")
+    assert any(f.id == "SUP-034" for f in r.findings)
+
+
+def test_rule_psv_014():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/168_psv014_apollo_mcp_cve_2026_35577"), p, "builtin:strict")
+    assert any(f.id == "PSV-014" for f in r.findings)

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -510,3 +510,47 @@ def test_163_mal067_glassworm_unicode_pua_eval():
 def test_164_sup033_openvsx_zip_slip():
     findings = _scan("examples/showcase/164_sup033_openvsx_zip_slip")
     assert any(f.id == "SUP-033" for f in findings.findings)
+
+
+def test_showcase_165_psv013_cursor_rce_cve_2026_31854():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/165_psv013_cursor_rce_cve_2026_31854"), p, "builtin:strict")
+    assert any(f.id == "PSV-013" for f in r.findings)
+
+
+def test_showcase_166_pinj022_nanobot_cve_2026_33654():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/166_pinj022_nanobot_cve_2026_33654"), p, "builtin:strict")
+    assert any(f.id == "PINJ-022" for f in r.findings)
+
+
+def test_showcase_167_sup034_claude_code_action_tra_2026_27():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/167_sup034_claude_code_action_tra_2026_27"), p, "builtin:strict")
+    assert any(f.id == "SUP-034" for f in r.findings)
+
+
+def test_showcase_168_psv014_apollo_mcp_cve_2026_35577():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/168_psv014_apollo_mcp_cve_2026_35577"), p, "builtin:strict")
+    assert any(f.id == "PSV-014" for f in r.findings)


### PR DESCRIPTION
## 2026-04-12

**Sources:**
- SentinelOne (CVE-2026-31854)
- NVD (CVE-2026-33654, CVE-2026-35577)
- Tenable (TRA-2026-27)

**Summary:**
Added detection for Cursor IDE RCE via indirect prompt injection, nanobot indirect prompt injection via email, claude-code-action arbitrary code execution via malicious .mcp.json, and Apollo MCP Server DNS rebinding.

**Rule Details:**
- `PSV-013`: Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection
- `PINJ-022`: nanobot CVE-2026-33654 Indirect Prompt Injection via Email
- `SUP-034`: claude-code-action Arbitrary Code Execution via Malicious .mcp.json
- `PSV-014`: Apollo MCP Server CVE-2026-35577 DNS Rebinding

**IOC/Corpus Updates:**
- Added 4 new organic eval holdouts to the corpus.
- Updated vulnerability database with CVE-2026-31854, CVE-2026-33654, TRA-2026-27, and CVE-2026-35577.

## 2026-04-11
rulepack: 2026.04.11.1
Three new detection rules, IOC enrichment, and vuln DB updates covering a critical MCP server RCE, a new GlassWorm Unicode steganography wave, and an OpenVSX marketplace Zip Slip vulnerability.
- Added `PSV-012` (critical): **aws-mcp-server command injection RCE (CVE-2026-5058 / CVE-2026-5059, ZDI-26-246/247)** — CVE-2026-5058 and CVE-2026-5059 (CVSS 9.8, published April 11, 2026) are critical command injection RCE vulnerabilities in aws-mcp-server. The flaw exists in the handling of the allowed-commands list: user-supplied strings are passed to system calls without proper validation, allowing unauthenticated remote attackers to execute arbitrary code in the context of the MCP server. No authentication is required. Apply vendor patches immediately. Until patched, restrict network access to the MCP server and validate all user-supplied input before passing to system calls.
- Added `MAL-067` (critical): **GlassWorm invisible Unicode PUA payload injection (eval via FE00-FE0F/E0100-E01EF encoding)** — GlassWorm (March 2026 wave, disclosed by Aikido Security) hides malicious payloads inside invisible Unicode PUA (Private Use Area) characters in the ranges U+FE00–U+FE0F and U+E0100–U+E01EF. The attack encodes a full JavaScript payload as invisible characters embedded in an apparently empty backtick string. At runtime, a small decoder maps each character's codepoint offset to bytes, reconstructs the payload, and passes it to `eval()`. The decoded payload fetches and executes a second-stage script (historically via Solana memo transactions as a C2 channel) capable of stealing tokens, credentials, and secrets. Affected ecosystems include npm packages (`@aifabrix/miso-client`, `@iflow-mcp/watercrawl-watercrawl-mcp`), VS Code extensions (`quartz.quartz-markdown-editor`), and 150+ GitHub repositories. This rule is distinct from MAL-066 (Zig dropper) and targets the Unicode encoding/decoding attack vector specifically.
- Added `SUP-033` (high): **OpenVSX Code Extension Marketplace Zip Slip vulnerability (CVE-2026-35454, pre-2.4.2)** — CVE-2026-35454 is a Zip Slip path traversal vulnerability in the Open VSX Code Extension Marketplace (versions prior to 2.4.2). During extension installation, maliciously crafted .vsix archives can use relative path components (e.g., `../../`) to write files outside the intended extraction directory, bypassing pre-publication security checks and enabling arbitrary file write on the marketplace server or client. Upgrade the Open VSX marketplace to version 2.4.2 or later.
- IOC update: added `aifabrix.io` and `iflow-mcp.io` (GlassWorm Unicode wave npm package domains) to domain IOC DB.
- Vuln DB update: added `aws-mcp-server` (CVE-2026-5058, critical) and `open-vsx-server` versions 2.0.0–2.4.1 (CVE-2026-35454, high, fixed 2.4.2) to npm vuln DB.
Sources:
- GitHub Advisory (GHSA-fjwc-hc62-p8h9 / CVE-2026-5058): https://github.com/advisories/GHSA-fjwc-hc62-p8h9
- ZDI (ZDI-26-246): https://www.zerodayinitiative.com/advisories/ZDI-26-246
- The Hacker Wire (CVE-2026-5058): https://www.thehackerwire.com/aws-mcp-server-remote-code-execution-via-command-injection-cve-2026-5058/
- Aikido Security (GlassWorm Unicode, 2026-03): https://www.aikido.dev/blog/glassworm-returns-unicode-attack-github-npm-vscode
- The Hacker News (GlassWorm Unicode): https://thehackernews.com/2026/03/glassworm-supply-chain-attack-abuses-72.html
- Afine (GlassWorm hunting): https://afine.com/blogs/hunting-glassworm-open-source-detection-for-invisible-supply-chain-payloads
- CVE Details (CVE-2026-35454): https://www.cvedetails.com/cve/CVE-2026-35454/
- ExpertInTheCloud (OpenVSX Zip Slip): https://expertinthecloud.co.za/tag/open-vsx-vulnerability-lets-malicious-extensions-slip-through/

## 2026-04-10
rulepack: 2026.04.10.1
Four new detection rules, 1 new IOC URL, and vuln DB updates covering a new GlassWorm campaign, two AI framework vulnerabilities, and a novel A2A protocol attack vector.
- Added `MAL-066` (critical): **GlassWorm Zig dropper via fake WakaTime OpenVSX extension (specstudio/code-wakatime-activity-tracker)** — Aikido Security disclosed a new GlassWorm campaign on April 8, 2026 that delivers a Zig-compiled native dropper via a fake WakaTime VS Code extension (`specstudio/code-wakatime-activity-tracker`) published on OpenVSX. The extension bundles `win.node` (PE32+ DLL) and `mac.node` (universal Mach-O) native Node.js addons compiled in Zig. On activation, the binary silently installs a second-stage malicious extension (`floktokbok.autoimport`, `autoimport-2.7.9.vsix`) into every IDE on the machine (VS Code, Cursor, Windsurf, VSCodium, Positron). The second-stage extension beacons to a Solana blockchain C2, exfiltrates secrets, and installs a persistent RAT. The dropper binary is hosted at `github.com/ColossusQuailPray/oiegjqde`. Remove `specstudio/code-wakatime-activity-tracker` and `floktokbok.autoimport` from all IDEs immediately, rotate all secrets, and check for `~/init.json` and `~/node-v22` persistence artifacts.
- Added `PSV-010` (high): **MCP Python SDK DNS rebinding vulnerability (CVE-2025-66416, mcp < 1.23.0)** — CVE-2025-66416 (GHSA-9h52-p55h-vw2f) is a DNS rebinding vulnerability in the MCP Python SDK (modelcontextprotocol/python-sdk) prior to version 1.23.0. HTTP-based MCP servers do not enable DNS rebinding protection by default, allowing a malicious website to make cross-origin requests to a locally running MCP server and potentially hijack tool execution. Upgrade `mcp` to 1.23.0 or later. This extends the existing vuln DB entry for GHSA-9h52-p55h-vw2f with a dedicated detection rule and adds affected versions 1.10.0–1.22.0 to the vuln DB.
- Added `PSV-011` (critical): **CrewAI prompt injection to RCE/SSRF chain (VU#221883, CVE-2026-2275/2285/2286/2287)** — VU#221883 (CERT/CC, disclosed 2026-03-30) describes four vulnerabilities in CrewAI that can be chained via prompt injection for sandbox escape and full RCE. CVE-2026-2275: `CodeInterpreterTool` falls back to `SandboxPython` when Docker is unavailable, enabling arbitrary C function calls via `ctypes`. CVE-2026-2287: CrewAI does not verify Docker is still running at runtime and falls back to unsafe sandbox mode. CVE-2026-2286: SSRF via RAG search tools that do not validate URLs, enabling access to internal services and cloud metadata endpoints (e.g., 169.254.169.254). CVE-2026-2285: Arbitrary local file read via JSON loader tool without path validation. Until patches are available, disable `allow_code_execution=True`, remove `CodeInterpreterTool` from agents, and restrict agent exposure to untrusted input.
- Added `PINJ-021` (high): **A2A agent card poisoning — adversarial instructions in agent card metadata** — Agent Card Poisoning (Keysight/CyPerf, March 2026) is a metadata injection vulnerability in the Google Agent2Agent (A2A) protocol. A malicious remote agent embeds adversarial instructions within its agent card metadata (served at `/.well-known/agent.json`). When the host LLM incorporates this poisoned metadata into its reasoning context, the injected instructions can influence tool-selection and execution decisions, causing the model to issue unintended tool calls, transmit sensitive user data to attacker-controlled endpoints, or silently hijack control flow during legitimate task delegation.
- IOC update: added `https://github.com/ColossusQuailPray/oiegjqde/releases/download/12/autoimport-2.7.9.vsix` (GlassWorm Zig dropper delivery URL) to URL IOC DB.
- Vuln DB update: added MCP Python SDK versions 1.10.0–1.22.0 as CVE-2025-66416 (high, fixed 1.23.0); added CrewAI versions 0.100.0–0.114.0 as VU#221883 (critical, fix pending).
Sources:
- Aikido Security (GlassWorm Zig dropper, 2026-04-08): https://www.aikido.dev/blog/glassworm-zig-dropper-infects-every-ide-on-your-machine
- The Hacker News (GlassWorm Zig, 2026-04-09): https://thehackernews.com/2026/04/glassworm-campaign-uses-zig-dropper-to.html