### PR TITLE
feat: pattern update 2026-04-13 — PSV-015 MCP Go SDK DNS rebinding CVE-2026-34742, PSV-016 mobile-mcp Android intent RCE CVE-2026-35394, PSV-017 OpenClaw WebSocket scope elevation CVE-2026-22172

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,19 @@
+## 2026-04-13
+rulepack: 2026.04.13.1
+Three new detection rules and vuln DB updates covering two new MCP ecosystem DNS rebinding vulnerabilities and a critical OpenClaw WebSocket authorization bypass.
+- Added `PSV-015` (high): **MCP Go SDK DNS rebinding vulnerability (CVE-2026-34742, go-sdk < v1.4.0)** — CVE-2026-34742 (GHSA-xw59-hvm2-8pj6, disclosed March 31, 2026) is a DNS rebinding vulnerability in the Model Context Protocol Go SDK prior to version v1.4.0. HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication. A malicious website can exploit this flaw to bypass same-origin policy restrictions and send requests to the local MCP server, enabling arbitrary tool invocation or resource access. This is distinct from PSV-010 (Python SDK, CVE-2025-66416) and SUP-016 (CSRF variant CVE-2026-33252). Upgrade `github.com/modelcontextprotocol/go-sdk` to v1.4.0 or later.
+- Added `PSV-016` (high): **mobile-mcp arbitrary Android intent execution via unvalidated URL (CVE-2026-35394, < 0.0.50)** — CVE-2026-35394 (GHSA-5qhv-x9j4-c3vm, CVSS 8.3, disclosed April 4–6, 2026) is a vulnerability in mobilenexthq mobile-mcp prior to version 0.0.50. The `mobile_open_url` tool passes user-supplied URLs directly to Android's intent system without any scheme validation, enabling arbitrary intent execution including phone calls (`tel:`), SMS (`sms:`), USSD codes (`ussd:`), and content provider access. This allows prompt injection attacks to "phish the AI" and trigger unauthorized device actions. Upgrade mobile-mcp to 0.0.50 or later and restrict access to the `mobile_open_url` tool.
+- Added `PSV-017` (high): **OpenClaw WebSocket authorization bypass — self-declared scope elevation (CVE-2026-22172, < 2026.3.12)** — CVE-2026-22172 (disclosed March 20, 2026) is a critical authorization bypass vulnerability in OpenClaw versions prior to 2026.3.12. The WebSocket connect path allows shared-token or password-authenticated connections to self-declare elevated scopes (e.g., `operator.admin`) without server-side binding validation. This enables attackers to perform admin-only gateway operations without proper authorization. Upgrade OpenClaw to version 2026.3.12 or later immediately.
+- Vuln DB update: added `github.com/modelcontextprotocol/go-sdk` versions v0.1.0–v1.3.0 as CVE-2026-34742 (high, fixed v1.4.0); added `mobile-mcp` versions 0.0.1–0.0.49 as CVE-2026-35394 (high, fixed 0.0.50); added `openclaw` versions 2026.1.1–2026.3.11 as CVE-2026-22172 (high, fixed 2026.3.12).
+Sources:
+- NVD (CVE-2026-34742): https://nvd.nist.gov/vuln/detail/CVE-2026-34742
+- GitHub Advisory (GHSA-xw59-hvm2-8pj6): https://github.com/modelcontextprotocol/go-sdk/security/advisories/GHSA-xw59-hvm2-8pj6
+- NVD (CVE-2026-35394): https://nvd.nist.gov/vuln/detail/CVE-2026-35394
+- Tenable (CVE-2026-35394): https://www.tenable.com/cve/CVE-2026-35394
+- GitHub Advisory (GHSA-5qhv-x9j4-c3vm): https://github.com/mobile-next/mobile-mcp/security/advisories/GHSA-5qhv-x9j4-c3vm
+- Tenable (CVE-2026-22172): https://www.tenable.com/cve/CVE-2026-22172
+- SentinelOne (CVE-2026-22172): https://www.sentinelone.com/vulnerability-database/cve-2026-22172/
+- The Hacker Wire (CVE-2026-22172): https://www.thehackerwire.com/openclaw-critical-websocket-authorization-bypass-cve-2026-22172/
 ## 2026-04-12
 
 **Sources:**

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -3,7 +3,7 @@
 > Auto-generated from `src/skillscan/data/rules/`. Do not edit by hand.
 > Run `python3 scripts/generate_examples_table.py` to regenerate.
 
-**200 static rules · 14 chain rules**
+**203 static rules · 14 chain rules**
 
 ## Static Rules
 
@@ -235,6 +235,9 @@
 | `PSV-008` | critical | Cursor IDE CVE-2026-22708 RCE via Shell Built-ins | platform_security, psv, cursor, rce, cve-2026-22708 |
 | `PSV-013` | high | Cursor IDE CVE-2026-31854 RCE via Indirect Prompt Injection | platform_security, psv, cursor, rce, cve-2026-31854, prompt-injection |
 | `PSV-014` | medium | Apollo MCP Server CVE-2026-35577 DNS Rebinding | platform_security, psv, apollo-mcp, dns-rebinding, cve-2026-35577 |
+| `PSV-015` | high | MCP Go SDK DNS rebinding vulnerability (CVE-2026-34742, go-sdk < v1.4.0) | platform_security, psv, mcp, go-sdk, dns-rebinding, cve-2026-34742, localhost |
+| `PSV-016` | high | mobile-mcp arbitrary Android intent execution via unvalidated URL (CVE-2026-35394, < 0.0.50) | platform_security, psv, mobile-mcp, android, intent-injection, rce, cve-2026-35394 |
+| `PSV-017` | high | OpenClaw WebSocket authorization bypass — self-declared scope elevation (CVE-2026-22172, < 2026.3.12) | platform_security, psv, openclaw, websocket, authorization-bypass, scope-elevation, cve-2026-22172 |
 
 ### Execution
 

--- a/examples/showcase/169_psv015_mcp_go_sdk_dns_rebinding/SKILL.md
+++ b/examples/showcase/169_psv015_mcp_go_sdk_dns_rebinding/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: mcp-go-sdk-dns-rebinding-test
+description: Test for MCP Go SDK DNS rebinding vulnerability CVE-2026-34742
+---
+# MCP Go SDK DNS Rebinding Test (CVE-2026-34742)
+
+This skill tests detection of CVE-2026-34742 (GHSA-xw59-hvm2-8pj6).
+
+The vulnerability affects github.com/modelcontextprotocol/go-sdk versions prior to v1.4.0.
+HTTP-based MCP servers do not enable DNS rebinding protection by default on localhost.
+
+```bash
+# Trigger pattern for PSV-015
+echo "CVE-2026-34742"
+echo "modelcontextprotocol/go-sdk dns rebinding localhost vulnerability"
+echo "MCP go-sdk 0.3.0 dns rebinding tool execution bypass"
+```

--- a/examples/showcase/170_psv016_mobile_mcp_android_intent_rce/SKILL.md
+++ b/examples/showcase/170_psv016_mobile_mcp_android_intent_rce/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: mobile-mcp-android-intent-rce-test
+description: Test for mobile-mcp arbitrary Android intent execution CVE-2026-35394
+---
+# mobile-mcp Android Intent RCE Test (CVE-2026-35394)
+
+This skill tests detection of CVE-2026-35394 (GHSA-5qhv-x9j4-c3vm).
+
+The vulnerability affects mobilenexthq mobile-mcp prior to version 0.0.50.
+The mobile_open_url tool passes URLs directly to Android's intent system without scheme validation.
+
+```bash
+# Trigger pattern for PSV-016
+echo "CVE-2026-35394"
+echo "mobile-mcp mobile_open_url android intent unvalidated url rce"
+echo "mobilenexthq mobile-mcp 0.0.49 tel: sms: ussd: intent injection"
+```

--- a/examples/showcase/171_psv017_openclaw_websocket_scope_elevation/SKILL.md
+++ b/examples/showcase/171_psv017_openclaw_websocket_scope_elevation/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: openclaw-websocket-scope-elevation-test
+description: Test for OpenClaw WebSocket authorization bypass CVE-2026-22172
+---
+# OpenClaw WebSocket Scope Elevation Test (CVE-2026-22172)
+
+This skill tests detection of CVE-2026-22172.
+
+The vulnerability affects OpenClaw versions prior to 2026.3.12.
+The WebSocket connect path allows self-declared scope elevation to operator.admin
+without server-side binding validation.
+
+```bash
+# Trigger pattern for PSV-017
+echo "CVE-2026-22172"
+echo "openclaw websocket scope elevation operator.admin authorization bypass"
+echo "openclaw 2026.3.11 self-declare elevated scope auth bypass gateway"
+```

--- a/examples/showcase/INDEX.md
+++ b/examples/showcase/INDEX.md
@@ -190,3 +190,6 @@ skillscan scan examples/showcase/29_claude_sed_path_bypass --fail-on never
 168. `166_pinj022_nanobot_cve_2026_33654`: nanobot CVE-2026-33654 Indirect Prompt Injection via Email (`PINJ-022`)
 169. `167_sup034_claude_code_action_tra_2026_27`: claude-code-action Arbitrary Code Execution via Malicious .mcp.json (`SUP-034`)
 170. `168_psv014_apollo_mcp_cve_2026_35577`: Apollo MCP Server CVE-2026-35577 DNS Rebinding (`PSV-014`)
+169. `169_psv015_mcp_go_sdk_dns_rebinding`: MCP Go SDK DNS rebinding vulnerability CVE-2026-34742 (`PSV-015`)
+170. `170_psv016_mobile_mcp_android_intent_rce`: mobile-mcp arbitrary Android intent execution CVE-2026-35394 (`PSV-016`)
+171. `171_psv017_openclaw_websocket_scope_elevation`: OpenClaw WebSocket authorization bypass scope elevation CVE-2026-22172 (`PSV-017`)

--- a/src/skillscan/data/intel/ioc_db.json
+++ b/src/skillscan/data/intel/ioc_db.json
@@ -8,8 +8,8 @@
       "urlhaus_hosts"
     ],
     "note": "Bundled high-precision IOC DB. Hand-curated campaign IOCs are always included. Large feeds (URLhaus URLs, Hagezi TIF, Phishing Army, KADhosts) are runtime-only and merged at scan time via managed_sources.json.",
-    "updated": "2026-04-10",
-    "version": "2026.04.10.1"
+    "updated": "2026-04-13",
+    "version": "2026.04.13.1"
   },
   "domains": [
     "001.smallnode.net",

--- a/src/skillscan/data/intel/vuln_db.json
+++ b/src/skillscan/data/intel/vuln_db.json
@@ -63,8 +63,8 @@
       "tough-cookie",
       "word-wrap"
     ],
-    "updated": "2026-04-10",
-    "version": "2026.04.10.1"
+    "updated": "2026-04-13",
+    "version": "2026.04.13.1"
   },
   "python": {
     "bittensor-wallet": {
@@ -1293,6 +1293,56 @@
         "fixed": "2.4.2",
         "summary": "Zip Slip path traversal vulnerability in Open VSX Code Extension Marketplace (CVE-2026-35454). Maliciously crafted .vsix archives can write files outside the intended extraction directory, bypassing pre-publication security checks."
       }
+    },
+    "mobile-mcp": {
+      "0.0.1": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.10": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.20": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.30": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.40": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.45": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.48": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      },
+      "0.0.49": {
+        "id": "CVE-2026-35394",
+        "severity": "high",
+        "fixed": "0.0.50",
+        "summary": "Arbitrary Android intent execution via unvalidated URL in mobile_open_url tool (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm). Allows tel:, sms:, ussd:, content: scheme injection."
+      }
     }
   },
   "pip": {
@@ -1361,6 +1411,92 @@
       "severity": "medium",
       "fixed": "1.7.0",
       "summary": "Apollo MCP Server DNS rebinding vulnerability on StreamableHTTP transport"
+    }
+  },
+  "go": {
+    "github.com/modelcontextprotocol/go-sdk": {
+      "v0.1.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      },
+      "v0.2.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      },
+      "v0.3.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      },
+      "v1.0.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      },
+      "v1.1.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      },
+      "v1.2.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      },
+      "v1.3.0": {
+        "id": "CVE-2026-34742",
+        "severity": "high",
+        "fixed": "v1.4.0",
+        "summary": "DNS rebinding vulnerability in MCP Go SDK HTTP servers (CVE-2026-34742, GHSA-xw59-hvm2-8pj6). HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication."
+      }
+    }
+  },
+  "openclaw": {
+    "openclaw": {
+      "2026.1.1": {
+        "id": "CVE-2026-22172",
+        "severity": "high",
+        "fixed": "2026.3.12",
+        "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
+      },
+      "2026.2.1": {
+        "id": "CVE-2026-22172",
+        "severity": "high",
+        "fixed": "2026.3.12",
+        "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
+      },
+      "2026.3.1": {
+        "id": "CVE-2026-22172",
+        "severity": "high",
+        "fixed": "2026.3.12",
+        "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
+      },
+      "2026.3.5": {
+        "id": "CVE-2026-22172",
+        "severity": "high",
+        "fixed": "2026.3.12",
+        "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
+      },
+      "2026.3.10": {
+        "id": "CVE-2026-22172",
+        "severity": "high",
+        "fixed": "2026.3.12",
+        "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
+      },
+      "2026.3.11": {
+        "id": "CVE-2026-22172",
+        "severity": "high",
+        "fixed": "2026.3.12",
+        "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
+      }
     }
   }
 }

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.04.12.1"
+version: "2026.04.13.1"
 static_rules:
   - id: MAL-001
     category: malware_pattern
@@ -6365,6 +6365,125 @@ static_rules:
         benchmark_set: core-static-v1
       references:
         - https://nvd.nist.gov/vuln/detail/CVE-2026-35577
+  - id: PSV-015
+    category: platform_security
+    severity: high
+    confidence: 0.93
+    title: MCP Go SDK DNS rebinding vulnerability (CVE-2026-34742, go-sdk < v1.4.0)
+    pattern: (?i)(?:CVE-2026-34742|GHSA-xw59-hvm2-8pj6|go[_\s-]?sdk[^\n]{0,80}dns[_\s-]?rebinding|modelcontextprotocol[/\\]go[_-]?sdk[^\n]{0,80}(?:1\.[0-3]\.|0\.[0-9]\.|dns|rebind|localhost)|mcp[^\n]{0,40}go[_\s-]?sdk[^\n]{0,80}(?:dns[_\s-]?rebind|localhost[^\n]{0,60}http|rebind[^\n]{0,60}tool))
+    mitigation: 'CVE-2026-34742 (GHSA-xw59-hvm2-8pj6) is a DNS rebinding vulnerability in the MCP Go SDK prior to v1.4.0. HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication. A malicious website can exploit this to bypass same-origin policy and invoke tools or access resources on the local MCP server. Upgrade github.com/modelcontextprotocol/go-sdk to v1.4.0 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-13'
+      updated: '2026-04-13'
+      tags:
+        - platform_security
+        - psv
+        - mcp
+        - go-sdk
+        - dns-rebinding
+        - cve-2026-34742
+        - localhost
+      last_modified: '2026-04-13'
+      techniques:
+        - id: EXEC-048
+          name: Execution or malware behavior
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-13'
+        last_modified: '2026-04-13'
+      quality:
+        precision_estimate: 0.93
+        benchmark_set: core-static-v1
+      references:
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-34742
+        - https://github.com/modelcontextprotocol/go-sdk/security/advisories/GHSA-xw59-hvm2-8pj6
+        - https://github.com/advisories/GHSA-xw59-hvm2-8pj6
+  - id: PSV-016
+    category: platform_security
+    severity: high
+    confidence: 0.94
+    title: mobile-mcp arbitrary Android intent execution via unvalidated URL (CVE-2026-35394, < 0.0.50)
+    pattern: (?i)(?:CVE-2026-35394|GHSA-5qhv-x9j4-c3vm|mobile[_-]?mcp[^\n]{0,80}(?:mobile[_-]?open[_-]?url|intent|android|unvalidat|rce|0\.0\.[0-4][0-9]\b)|mobile[_-]?open[_-]?url[^\n]{0,120}(?:tel:|sms:|ussd:|content:|intent:|CVE-2026-35394)|mobilenexthq[^\n]{0,80}(?:mobile[_-]?mcp|open[_-]?url|intent|android))
+    mitigation: 'CVE-2026-35394 (GHSA-5qhv-x9j4-c3vm) is a critical vulnerability in mobile-mcp (mobilenexthq) prior to version 0.0.50. The mobile_open_url tool passes user-supplied URLs directly to Android''s intent system without scheme validation, allowing arbitrary intent execution including phone calls (tel:), SMS (sms:), USSD codes (ussd:), and content provider access. Upgrade mobile-mcp to 0.0.50 or later. Until patched, restrict access to the mobile_open_url tool and validate all URL schemes before passing to Android intents.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-13'
+      updated: '2026-04-13'
+      tags:
+        - platform_security
+        - psv
+        - mobile-mcp
+        - android
+        - intent-injection
+        - rce
+        - cve-2026-35394
+      last_modified: '2026-04-13'
+      techniques:
+        - id: EXEC-048
+          name: Execution or malware behavior
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-13'
+        last_modified: '2026-04-13'
+      quality:
+        precision_estimate: 0.94
+        benchmark_set: core-static-v1
+      references:
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-35394
+        - https://github.com/mobile-next/mobile-mcp/security/advisories/GHSA-5qhv-x9j4-c3vm
+        - https://www.tenable.com/cve/CVE-2026-35394
+  - id: PSV-017
+    category: platform_security
+    severity: high
+    confidence: 0.95
+    title: OpenClaw WebSocket authorization bypass — self-declared scope elevation (CVE-2026-22172, < 2026.3.12)
+    pattern: (?i)(?:CVE-2026-22172|openclaw[^\n]{0,80}(?:websocket|scope[_\s-]?elevat|operator\.admin|auth[_\s-]?bypass|2026\.3\.(?:[0-9]|1[01])\b)|operator\.admin[^\n]{0,80}(?:openclaw|websocket|scope|gateway)|scope[_\s-]?elevat[^\n]{0,80}openclaw|self[_\s-]?declar[^\n]{0,80}(?:scope|openclaw|operator\.admin))
+    mitigation: 'CVE-2026-22172 is a critical authorization bypass vulnerability in OpenClaw prior to version 2026.3.12. The WebSocket connect path allows shared-token or password-authenticated connections to self-declare elevated scopes (e.g., operator.admin) without server-side binding validation. This enables attackers to perform admin-only gateway operations without proper authorization. Upgrade OpenClaw to version 2026.3.12 or later immediately.'
+    metadata:
+      version: 1.0.0
+      status: active
+      author: skillscan
+      created: '2026-04-13'
+      updated: '2026-04-13'
+      tags:
+        - platform_security
+        - psv
+        - openclaw
+        - websocket
+        - authorization-bypass
+        - scope-elevation
+        - cve-2026-22172
+      last_modified: '2026-04-13'
+      techniques:
+        - id: EXEC-048
+          name: Execution or malware behavior
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-13'
+        last_modified: '2026-04-13'
+      quality:
+        precision_estimate: 0.95
+        benchmark_set: core-static-v1
+      references:
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-22172
+        - https://www.tenable.com/cve/CVE-2026-22172
+        - https://www.sentinelone.com/vulnerability-database/cve-2026-22172/
+        - https://www.thehackerwire.com/openclaw-critical-websocket-authorization-bypass-cve-2026-22172/
+
 capability_patterns:
   shell_execution: \b(subprocess|os\.system|bash|powershell)\b
   network_access: \b(requests\.|fetch\(|axios|http[s]?://|socket)\b

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2262,3 +2262,79 @@ def test_rule_psv_014():
     p = load_builtin_policy("strict")
     r = scan(Path("examples/showcase/168_psv014_apollo_mcp_cve_2026_35577"), p, "builtin:strict")
     assert any(f.id == "PSV-014" for f in r.findings)
+
+
+def test_psv015_mcp_go_sdk_dns_rebinding() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-015"]
+    assert rules, "PSV-015 not found"
+    rule = rules[0]
+    assert rule.pattern.search("CVE-2026-34742 mcp go-sdk dns rebinding") is not None
+    assert rule.pattern.search("GHSA-xw59-hvm2-8pj6 modelcontextprotocol go-sdk") is not None
+    assert rule.pattern.search("modelcontextprotocol/go-sdk 0.3.0 dns rebinding localhost") is not None
+    assert rule.pattern.search("MCP go sdk 1.2.0 dns rebinding tool execution bypass") is not None
+    assert rule.pattern.search("mcp go sdk dns rebind tool invocation") is not None
+    assert rule.pattern.search("go sdk dns rebinding localhost http server") is not None
+    assert rule.pattern.search("modelcontextprotocol/go-sdk v1.4.0 release notes") is None
+    assert rule.pattern.search("install github.com/modelcontextprotocol/go-sdk v1.5.0") is None
+
+
+def test_psv016_mobile_mcp_android_intent_rce() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-016"]
+    assert rules, "PSV-016 not found"
+    rule = rules[0]
+    assert rule.pattern.search("CVE-2026-35394 mobile-mcp android intent rce") is not None
+    assert rule.pattern.search("GHSA-5qhv-x9j4-c3vm mobile-mcp vulnerability") is not None
+    assert rule.pattern.search("mobile-mcp mobile_open_url android intent unvalidated") is not None
+    assert rule.pattern.search("mobilenexthq mobile-mcp 0.0.49 intent injection") is not None
+    assert rule.pattern.search("mobile_open_url tel: sms: ussd: intent CVE-2026-35394") is not None
+    assert rule.pattern.search("mobile-mcp 0.0.50 changelog release notes") is None
+    assert rule.pattern.search("use mobile-mcp 0.0.50 for device testing") is None
+
+
+def test_psv017_openclaw_websocket_scope_elevation() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-017"]
+    assert rules, "PSV-017 not found"
+    rule = rules[0]
+    assert rule.pattern.search("CVE-2026-22172 openclaw websocket scope elevation") is not None
+    assert rule.pattern.search("openclaw 2026.3.11 websocket auth bypass operator.admin") is not None
+    assert rule.pattern.search("openclaw scope elevation operator.admin authorization bypass") is not None
+    assert rule.pattern.search("self-declare elevated scope openclaw websocket gateway") is not None
+    assert rule.pattern.search("operator.admin openclaw websocket scope self-declared") is not None
+    assert rule.pattern.search("openclaw 2026.3.12 release notes") is None
+    assert rule.pattern.search("openclaw gateway connection established") is None
+
+
+def test_rule_psv_015():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/169_psv015_mcp_go_sdk_dns_rebinding"), p, "builtin:strict")
+    assert any(f.id == "PSV-015" for f in r.findings)
+
+
+def test_rule_psv_016():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/170_psv016_mobile_mcp_android_intent_rce"), p, "builtin:strict")
+    assert any(f.id == "PSV-016" for f in r.findings)
+
+
+def test_rule_psv_017():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/171_psv017_openclaw_websocket_scope_elevation"), p, "builtin:strict")
+    assert any(f.id == "PSV-017" for f in r.findings)

--- a/tests/test_showcase_examples.py
+++ b/tests/test_showcase_examples.py
@@ -554,3 +554,36 @@ def test_showcase_168_psv014_apollo_mcp_cve_2026_35577():
     p = load_builtin_policy("strict")
     r = scan(Path("examples/showcase/168_psv014_apollo_mcp_cve_2026_35577"), p, "builtin:strict")
     assert any(f.id == "PSV-014" for f in r.findings)
+
+
+def test_showcase_169_psv015_mcp_go_sdk_dns_rebinding():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/169_psv015_mcp_go_sdk_dns_rebinding"), p, "builtin:strict")
+    assert any(f.id == "PSV-015" for f in r.findings)
+
+
+def test_showcase_170_psv016_mobile_mcp_android_intent_rce():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/170_psv016_mobile_mcp_android_intent_rce"), p, "builtin:strict")
+    assert any(f.id == "PSV-016" for f in r.findings)
+
+
+def test_showcase_171_psv017_openclaw_websocket_scope_elevation():
+    from pathlib import Path
+
+    from skillscan.analysis import scan
+    from skillscan.policies import load_builtin_policy
+
+    p = load_builtin_policy("strict")
+    r = scan(Path("examples/showcase/171_psv017_openclaw_websocket_scope_elevation"), p, "builtin:strict")
+    assert any(f.id == "PSV-017" for f in r.findings)


### PR DESCRIPTION
## Pattern Update 2026-04-13 — rulepack `2026.04.13.1`

### New Rules

| Rule | Severity | Title | CVE |
|------|----------|-------|-----|
| `PSV-015` | high | MCP Go SDK DNS rebinding vulnerability | CVE-2026-34742 / GHSA-xw59-hvm2-8pj6 |
| `PSV-016` | high | mobile-mcp arbitrary Android intent execution via unvalidated URL | CVE-2026-35394 / GHSA-5qhv-x9j4-c3vm |
| `PSV-017` | high | OpenClaw WebSocket authorization bypass — self-declared scope elevation | CVE-2026-22172 |

### Summary

**PSV-015** (CVE-2026-34742, GHSA-xw59-hvm2-8pj6): DNS rebinding vulnerability in the MCP Go SDK prior to v1.4.0. HTTP-based MCP servers do not enable DNS rebinding protection by default when running on localhost without authentication. A malicious website can bypass same-origin policy to invoke tools on the local MCP server. Distinct from PSV-010 (Python SDK) and SUP-016 (CSRF variant). Upgrade `github.com/modelcontextprotocol/go-sdk` to v1.4.0+.

**PSV-016** (CVE-2026-35394, GHSA-5qhv-x9j4-c3vm, CVSS 8.3): The `mobile_open_url` tool in mobile-mcp (mobilenexthq) prior to 0.0.50 passes user-supplied URLs directly to Android's intent system without scheme validation. Enables arbitrary intent execution including `tel:`, `sms:`, `ussd:`, `content:` schemes. Upgrade to 0.0.50+.

**PSV-017** (CVE-2026-22172): Authorization bypass in OpenClaw WebSocket connect path prior to 2026.3.12. Allows self-declaration of elevated scopes (e.g., `operator.admin`) without server-side binding validation, enabling admin-only gateway operations. Upgrade to 2026.3.12+.

### Artifacts

- 3 new static rules in `src/skillscan/data/rules/default.yaml`
- 3 new showcase fixtures (`169`–`171`) with corresponding `INDEX.md` entries
- `docs/EXAMPLES.md` regenerated (272 lines)
- `tests/test_rules.py` and `tests/test_showcase_examples.py` updated with 9 new test functions
- `vuln_db.json` updated with CVE-2026-34742 (Go), CVE-2026-35394 (npm), CVE-2026-22172 (openclaw)
- `ioc_db.json` meta version bumped to `2026.04.13.1`
- `PATTERN_UPDATES.md` updated with source-backed rationale

### Sources
- NVD CVE-2026-34742: https://nvd.nist.gov/vuln/detail/CVE-2026-34742
- GHSA-xw59-hvm2-8pj6: https://github.com/modelcontextprotocol/go-sdk/security/advisories/GHSA-xw59-hvm2-8pj6
- NVD CVE-2026-35394: https://nvd.nist.gov/vuln/detail/CVE-2026-35394
- GHSA-5qhv-x9j4-c3vm: https://github.com/mobile-next/mobile-mcp/security/advisories/GHSA-5qhv-x9j4-c3vm
- Tenable CVE-2026-22172: https://www.tenable.com/cve/CVE-2026-22172
- SentinelOne CVE-2026-22172: https://www.sentinelone.com/vulnerability-database/cve-2026-22172/