### PR TITLE
chore: pattern update 2026-04-19 — 6 new PSV rules

### DIFF
--- a/PATTERN_UPDATES.md
+++ b/PATTERN_UPDATES.md
@@ -1,3 +1,17 @@
+## 2026-04-19
+rulepack: 2026.04.19.1
+Six new platform security rules covering mcp-neo4j command injection RCE, AAP MCP server log injection, and four OpenClaw privilege escalation and access control vulnerabilities.
+- Added `PSV-026` (high): **mcp-neo4j SSE command injection RCE (CVE-2025-56406)** — CVE-2025-56406 is a command injection vulnerability in mcp-neo4j version 0.3.0. The unauthenticated SSE (Server-Sent Events) service endpoint allows attackers to execute arbitrary commands or exfiltrate Neo4j database contents. Bind the mcp-neo4j service exclusively to localhost, deploy behind a reverse proxy with authentication, or restrict access via firewall rules.
+- Added `PSV-027` (medium): **AAP MCP Server log injection via unsanitized toolsetroute (CVE-2026-6494)** — CVE-2026-6494 is a log injection vulnerability in the Red Hat AAP MCP server (CVSS 5.3). An unauthenticated remote attacker can inject ANSI escape sequences and newlines via the unsanitized toolsetroute parameter, forging log entries to facilitate social engineering attacks that trick operators into executing dangerous commands or visiting malicious URLs.
+- Added `PSV-028` (high): **OpenClaw privilege escalation via device.pair.approve scope validation bypass (CVE-2026-35639)** — CVE-2026-35639 (CVSS 8.7, CWE-648) is a privilege escalation vulnerability in OpenClaw prior to version 2026.3.22. Improper scope validation in the device.pair.approve flow allows attackers to escalate privileges during device pairing approval.
+- Added `PSV-029` (high): **OpenClaw privilege escalation via silent local shared-auth reconnect (CVE-2026-35625)** — CVE-2026-35625 (CVSS 8.5, CWE-648) is a privilege escalation vulnerability in OpenClaw prior to version 2026.3.25. The silent local shared-auth reconnect mechanism allows attackers to silently re-establish authenticated sessions with elevated privileges.
+- Added `PSV-030` (high): **OpenClaw improper access control in /sessions/:sessionKey/kill endpoint (CVE-2026-34512)** — CVE-2026-34512 (CVSS 7.2, CWE-863) is an improper access control vulnerability in OpenClaw prior to version 2026.3.25. The /sessions/:sessionKey/kill endpoint does not properly validate authorization, allowing unauthorized users to terminate active sessions.
+- Added `PSV-031` (high): **OpenClaw privilege escalation via chat.send to allowlist persistence (CVE-2026-35621)** — CVE-2026-35621 (CVSS 7.1, CWE-862) is a privilege escalation vulnerability in OpenClaw prior to version 2026.3.24. Attackers can use the chat.send endpoint to persist entries in the allowlist, achieving persistent privilege escalation.
+- Vuln DB: added mcp-neo4j (CVE-2025-56406), aap-mcp-server (CVE-2026-6494), and four new OpenClaw CVE entries (CVE-2026-35639, CVE-2026-35625, CVE-2026-34512, CVE-2026-35621).
+Sources:
+- SentinelOne Vulnerability Database: https://www.sentinelone.com/vulnerability-database/cve-2025-56406/
+- Red Hat Security Advisory: https://access.redhat.com/security/cve/cve-2026-6494
+- OpenClaw CVE Tracker: https://github.com/jgamblin/OpenClawCVEs
 ## 2026-04-18
 rulepack: 2026.04.18.1
 Three new detection rules, IOC enrichment, and vuln DB updates covering the gemini-ai-checker malicious npm package (OtterCookie/Contagious Interview AI tool token stealer), Apache SkyWalking MCP SSRF (CVE-2026-34476), and the Open VSX pre-publish scanning bypass (Open Sesame).

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -3,7 +3,7 @@
 > Auto-generated from `src/skillscan/data/rules/`. Do not edit by hand.
 > Run `python3 scripts/generate_examples_table.py` to regenerate.
 
-**226 static rules · 14 chain rules**
+**232 static rules · 14 chain rules**
 
 ## Static Rules
 
@@ -259,6 +259,12 @@
 | `PSV-023` | critical | nginx-ui MCP endpoint authentication bypass — unauthenticated nginx takeover (CVE-2026-33032, <= 2.3.5) | platform_security, psv, nginx, mcp_server, auth_bypass, actively_exploited, cve-2026-33032 |
 | `PSV-024` | high | Apache SkyWalking MCP SSRF via SW-URL Header (CVE-2026-34476) | platform_security, psv, apache, skywalking, mcp_server, ssrf, cve-2026-34476 |
 | `PSV-025` | high | Open VSX Pre-Publish Scanning Bypass (Open Sesame) | platform_security, psv, openvsx, scan_bypass, fail_open |
+| `PSV-026` | high | mcp-neo4j SSE command injection RCE (CVE-2025-56406, mcp-neo4j 0.3.0) | platform_security, psv, mcp, neo4j, command_injection, rce |
+| `PSV-027` | medium | AAP MCP Server log injection via unsanitized toolsetroute (CVE-2026-6494) | platform_security, psv, mcp, aap, log_injection, social_engineering |
+| `PSV-028` | high | OpenClaw privilege escalation via device.pair.approve scope validation bypass (CVE-2026-35639, < 2026.3.22) | platform_security, psv, openclaw, privilege_escalation, device_pairing |
+| `PSV-029` | high | OpenClaw privilege escalation via silent local shared-auth reconnect (CVE-2026-35625, < 2026.3.25) | platform_security, psv, openclaw, privilege_escalation, authentication_bypass |
+| `PSV-030` | high | OpenClaw improper access control in /sessions/:sessionKey/kill endpoint (CVE-2026-34512, < 2026.3.25) | platform_security, psv, openclaw, access_control, session_management |
+| `PSV-031` | high | OpenClaw privilege escalation via chat.send to allowlist persistence (CVE-2026-35621, < 2026.3.24) | platform_security, psv, openclaw, privilege_escalation, allowlist_bypass |
 
 ### Execution
 

--- a/src/skillscan/data/intel/vuln_db.json
+++ b/src/skillscan/data/intel/vuln_db.json
@@ -63,8 +63,8 @@
       "tough-cookie",
       "word-wrap"
     ],
-    "updated": "2026-04-13",
-    "version": "2026.04.13.1"
+    "updated": "2026-04-19",
+    "version": "2026.04.19.1"
   },
   "python": {
     "bittensor-wallet": {
@@ -1641,6 +1641,30 @@
         "fixed": "2026.3.12",
         "summary": "Authorization bypass in OpenClaw WebSocket connect path (CVE-2026-22172). Allows self-declaration of elevated scopes (operator.admin) without server-side binding, enabling admin-only gateway operations."
       }
+    },
+    "< 2026.3.22 (CVE-2026-35639)": {
+      "id": "CVE-2026-35639",
+      "severity": "high",
+      "fixed": "2026.3.22",
+      "description": "Privilege escalation via device.pair.approve scope validation bypass"
+    },
+    "< 2026.3.25 (CVE-2026-35625)": {
+      "id": "CVE-2026-35625",
+      "severity": "high",
+      "fixed": "2026.3.25",
+      "description": "Privilege escalation via silent local shared-auth reconnect"
+    },
+    "< 2026.3.25 (CVE-2026-34512)": {
+      "id": "CVE-2026-34512",
+      "severity": "high",
+      "fixed": "2026.3.25",
+      "description": "Improper access control in /sessions/:sessionKey/kill endpoint"
+    },
+    "< 2026.3.24 (CVE-2026-35621)": {
+      "id": "CVE-2026-35621",
+      "severity": "high",
+      "fixed": "2026.3.24",
+      "description": "Privilege escalation via chat.send to allowlist persistence"
     }
   },
   "n8n-mcp": {
@@ -1729,6 +1753,22 @@
       "severity": "high",
       "fixed": "0.2.0",
       "summary": "Apache SkyWalking MCP 0.1.0 SSRF via SW-URL Header (CVE-2026-34476). Attackers can forge server-side requests to internal resources by manipulating the SW-URL header. Upgrade to 0.2.0 or later."
+    }
+  },
+  "mcp-neo4j": {
+    "0.3.0": {
+      "id": "CVE-2025-56406",
+      "severity": "high",
+      "fixed": "N/A",
+      "description": "Command injection via unauthenticated SSE service endpoint allows RCE"
+    }
+  },
+  "aap-mcp-server": {
+    "all": {
+      "id": "CVE-2026-6494",
+      "severity": "medium",
+      "fixed": "N/A",
+      "description": "Log injection via unsanitized toolsetroute parameter enables social engineering"
     }
   }
 }

--- a/src/skillscan/data/manifest.json
+++ b/src/skillscan/data/manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": "2026.04.19.1",
+  "released_at": "2026-04-19T17:14:33.134970+00:00",
+  "files": {
+    "intel/ioc_db.json": {
+      "sha256": "f33acd08dd3ce5b2134eb69f374103ecbc26ef5a46ceccb9f6e94dda34570aeb"
+    },
+    "intel/managed_sources.json": {
+      "sha256": "aef9d1e320a08b256374b1917520d035dfcd78476bd7c5b4895a5cf3e647edce"
+    },
+    "intel/vuln_db.json": {
+      "sha256": "edeef40e2b8cb212af93bd14d0d26ef029927a235b72efd5d8846e48caecbf97"
+    },
+    "rules/ast_flows.yaml": {
+      "sha256": "31e2cb8954d66d9818e868a7b596bb19585c1569c4475e797fd66f5c14eba25e"
+    },
+    "rules/default.yaml": {
+      "sha256": "d85fc45b38fb2a9a23a15cc83c77365e46c39ac93b1cd7ff1254198d8d123f4d"
+    },
+    "rules/multilang.yaml": {
+      "sha256": "1d4784072b02aa40215be0974f87d8832c6bd1e7d0a0d7957e1a4228bce5afe1"
+    }
+  }
+}

--- a/src/skillscan/data/rules/default.yaml
+++ b/src/skillscan/data/rules/default.yaml
@@ -1,4 +1,4 @@
-version: "2026.04.18.1"
+version: "2026.04.19.1"
 static_rules:
   - id: MAL-001
     category: malware_pattern
@@ -12064,6 +12064,346 @@ static_rules:
       ## References
 
       - The Hacker News: https://thehackernews.com/2026/03/open-vsx-bug-let-malicious-vs-code.html
+    test_expect: fires
+  - id: PSV-026
+    category: platform_security
+    severity: high
+    confidence: 0.9
+    title: mcp-neo4j SSE command injection RCE (CVE-2025-56406, mcp-neo4j 0.3.0)
+    pattern: (?i)(?:CVE-2025-56406|mcp[_\s-]?neo4j[^\n]{0,120}(?:command[_\s-]?inject|RCE|SSE[_\s-]?(?:service|endpoint)|unauthenticat|arbitrary[_\s-]?command)|neo4j[^\n]{0,80}(?:mcp|SSE)[^\n]{0,80}(?:inject|RCE|exploit|unauthenticat))
+    mitigation: 'CVE-2025-56406 is a command injection vulnerability in mcp-neo4j version 0.3.0. The unauthenticated SSE (Server-Sent Events) service endpoint allows attackers to execute arbitrary commands or exfiltrate Neo4j database contents. Bind the mcp-neo4j service exclusively to localhost, deploy behind a reverse proxy with authentication, or restrict access via firewall rules.'
+    metadata:
+      version: 1.0.0
+      status: active
+      techniques:
+        - id: PSV-026
+          name: Platform security vulnerability
+      tags:
+        - platform_security
+        - psv
+        - mcp
+        - neo4j
+        - command_injection
+        - rce
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-19'
+        last_modified: '2026-04-19'
+      quality:
+        precision_estimate: 0.9
+        benchmark_set: core-static-v1
+      references:
+        - https://www.sentinelone.com/vulnerability-database/cve-2025-56406/
+        - https://nvd.nist.gov/vuln/detail/CVE-2025-56406
+      author: skillscan
+      created: '2026-04-19'
+      last_modified: '2026-04-19'
+      updated: '2026-04-19'
+    test_input: |
+      ---
+      name: neo4j-analytics-mcp
+      description: MCP server for Neo4j graph database analytics
+      ---
+
+      # Neo4j Analytics MCP Server
+
+      This MCP server provides graph analytics capabilities via Neo4j.
+
+      ## Security Advisory
+
+      CVE-2025-56406 affects mcp-neo4j version 0.3.0. The unauthenticated SSE
+      endpoint allows command injection and arbitrary command execution. An attacker
+      with network access to the mcp-neo4j SSE service can execute arbitrary
+      commands on the host system.
+
+      ## Deployment
+
+      Bind to 0.0.0.0:8080 for network access:
+
+      ```yaml
+      server:
+        host: 0.0.0.0
+        port: 8080
+        sse_enabled: true
+      ```
+    test_expect: fires
+  - id: PSV-027
+    category: platform_security
+    severity: medium
+    confidence: 0.85
+    title: AAP MCP Server log injection via unsanitized toolsetroute (CVE-2026-6494)
+    pattern: (?i)(?:CVE-2026-6494|aap[_\s-]?mcp[_\s-]?server[^\n]{0,120}(?:log[_\s-]?inject|toolsetroute|ANSI[_\s-]?escape|social[_\s-]?engineer|unsanitiz)|toolsetroute[^\n]{0,80}(?:inject|sanitiz|ANSI|escape[_\s-]?sequence|log[_\s-]?forg))
+    mitigation: 'CVE-2026-6494 is a log injection vulnerability in the Red Hat AAP MCP server. An unauthenticated remote attacker can inject ANSI escape sequences and newlines via the unsanitized toolsetroute parameter, forging log entries to facilitate social engineering attacks that trick operators into executing dangerous commands or visiting malicious URLs. Apply the Red Hat security patch when available and sanitize all log inputs.'
+    metadata:
+      version: 1.0.0
+      status: active
+      techniques:
+        - id: PSV-027
+          name: Platform security vulnerability
+      tags:
+        - platform_security
+        - psv
+        - mcp
+        - aap
+        - log_injection
+        - social_engineering
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-19'
+        last_modified: '2026-04-19'
+      quality:
+        precision_estimate: 0.85
+        benchmark_set: core-static-v1
+      references:
+        - https://access.redhat.com/security/cve/cve-2026-6494
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-6494
+      author: skillscan
+      created: '2026-04-19'
+      last_modified: '2026-04-19'
+      updated: '2026-04-19'
+    test_input: |
+      ---
+      name: aap-automation-skill
+      description: Ansible Automation Platform MCP integration
+      ---
+
+      # AAP MCP Server Integration
+
+      This skill integrates with the Red Hat AAP MCP server.
+
+      ## Security Advisory
+
+      CVE-2026-6494 affects the AAP MCP server. An unauthenticated remote attacker
+      can exploit a log injection vulnerability by sending specially crafted input
+      to the toolsetroute parameter. This parameter is not properly sanitized before
+      being written to logs, allowing the attacker to inject ANSI escape sequences
+      and newlines to forge log entries for social engineering attacks.
+    test_expect: fires
+  - id: PSV-028
+    category: platform_security
+    severity: high
+    confidence: 0.9
+    title: OpenClaw privilege escalation via device.pair.approve scope validation bypass (CVE-2026-35639, < 2026.3.22)
+    pattern: (?i)(?:CVE-2026-35639|openclaw[^\n]{0,80}(?:device\.pair\.approve|pair[_\s-]?approve[_\s-]?scope|scope[_\s-]?validat[^\n]{0,40}pair|2026\.3\.(?:1[0-9]|2[01])\b[^\n]{0,40}(?:priv|escal|scope))|device\.pair\.approve[^\n]{0,80}(?:scope|validat|bypass|escal|openclaw))
+    mitigation: 'CVE-2026-35639 (CVSS 8.7, CWE-648) is a privilege escalation vulnerability in OpenClaw prior to version 2026.3.22. Improper scope validation in the device.pair.approve flow allows attackers to escalate privileges during device pairing approval. Upgrade OpenClaw to version 2026.3.22 or later immediately.'
+    metadata:
+      version: 1.0.0
+      status: active
+      techniques:
+        - id: PSV-028
+          name: Platform security vulnerability
+      tags:
+        - platform_security
+        - psv
+        - openclaw
+        - privilege_escalation
+        - device_pairing
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-19'
+        last_modified: '2026-04-19'
+      quality:
+        precision_estimate: 0.9
+        benchmark_set: core-static-v1
+      references:
+        - https://github.com/jgamblin/OpenClawCVEs
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-35639
+      author: skillscan
+      created: '2026-04-19'
+      last_modified: '2026-04-19'
+      updated: '2026-04-19'
+    test_input: |
+      ---
+      name: openclaw-device-manager
+      description: Manage OpenClaw device pairing and authentication
+      ---
+
+      # OpenClaw Device Manager
+
+      This skill manages device pairing for OpenClaw instances.
+
+      ## Security Notice
+
+      CVE-2026-35639 affects OpenClaw versions prior to 2026.3.22. A privilege
+      escalation vulnerability exists in the device.pair.approve scope validation
+      flow. Attackers can bypass scope validation during device pairing approval
+      to escalate their privileges beyond intended authorization levels.
+
+      ## Affected Versions
+
+      OpenClaw < 2026.3.22 is vulnerable. The device.pair.approve endpoint does
+      not properly validate the requested scope against the caller's actual
+      permissions, allowing scope elevation.
+    test_expect: fires
+  - id: PSV-029
+    category: platform_security
+    severity: high
+    confidence: 0.9
+    title: OpenClaw privilege escalation via silent local shared-auth reconnect (CVE-2026-35625, < 2026.3.25)
+    pattern: (?i)(?:CVE-2026-35625|openclaw[^\n]{0,80}(?:shared[_\s-]?auth[_\s-]?reconnect|silent[_\s-]?(?:local[_\s-]?)?(?:shared[_\s-]?)?auth[_\s-]?reconnect|2026\.3\.(?:1[0-9]|2[0-4])\b[^\n]{0,40}(?:priv|escal|shared[_\s-]?auth))|shared[_\s-]?auth[_\s-]?reconnect[^\n]{0,80}(?:priv|escal|bypass|openclaw|silent))
+    mitigation: 'CVE-2026-35625 (CVSS 8.5, CWE-648) is a privilege escalation vulnerability in OpenClaw prior to version 2026.3.25. The silent local shared-auth reconnect mechanism allows attackers to silently re-establish authenticated sessions with elevated privileges. Upgrade OpenClaw to version 2026.3.25 or later immediately.'
+    metadata:
+      version: 1.0.0
+      status: active
+      techniques:
+        - id: PSV-029
+          name: Platform security vulnerability
+      tags:
+        - platform_security
+        - psv
+        - openclaw
+        - privilege_escalation
+        - authentication_bypass
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-19'
+        last_modified: '2026-04-19'
+      quality:
+        precision_estimate: 0.9
+        benchmark_set: core-static-v1
+      references:
+        - https://github.com/jgamblin/OpenClawCVEs
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-35625
+      author: skillscan
+      created: '2026-04-19'
+      last_modified: '2026-04-19'
+      updated: '2026-04-19'
+    test_input: |
+      ---
+      name: openclaw-auth-manager
+      description: OpenClaw authentication and session management
+      ---
+
+      # OpenClaw Auth Manager
+
+      Manages authentication flows for OpenClaw deployments.
+
+      ## Security Advisory
+
+      CVE-2026-35625 affects OpenClaw versions prior to 2026.3.25. A privilege
+      escalation vulnerability exists in the silent local shared-auth reconnect
+      mechanism. When a local client reconnects using shared authentication tokens,
+      the server does not properly re-validate the session's privilege level,
+      allowing attackers to silently escalate privileges.
+    test_expect: fires
+  - id: PSV-030
+    category: platform_security
+    severity: high
+    confidence: 0.9
+    title: OpenClaw improper access control in /sessions/:sessionKey/kill endpoint (CVE-2026-34512, < 2026.3.25)
+    pattern: (?i)(?:CVE-2026-34512|openclaw[^\n]{0,80}(?:/sessions/[^\n]{0,40}(?:kill|terminat)|session[_\s-]?key[_\s-]?kill|2026\.3\.(?:1[0-9]|2[0-4])\b[^\n]{0,40}(?:session|kill|access[_\s-]?control))|/sessions/[^\n]{0,20}(?:sessionKey|:sessionKey)[^\n]{0,20}/kill[^\n]{0,80}(?:access[_\s-]?control|unauthoriz|openclaw))
+    mitigation: 'CVE-2026-34512 (CVSS 7.2, CWE-863) is an improper access control vulnerability in OpenClaw prior to version 2026.3.25. The /sessions/:sessionKey/kill endpoint does not properly validate authorization, allowing unauthorized users to terminate active sessions. Upgrade OpenClaw to version 2026.3.25 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      techniques:
+        - id: PSV-030
+          name: Platform security vulnerability
+      tags:
+        - platform_security
+        - psv
+        - openclaw
+        - access_control
+        - session_management
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-19'
+        last_modified: '2026-04-19'
+      quality:
+        precision_estimate: 0.9
+        benchmark_set: core-static-v1
+      references:
+        - https://github.com/jgamblin/OpenClawCVEs
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-34512
+      author: skillscan
+      created: '2026-04-19'
+      last_modified: '2026-04-19'
+      updated: '2026-04-19'
+    test_input: |
+      ---
+      name: openclaw-session-admin
+      description: OpenClaw session administration tool
+      ---
+
+      # OpenClaw Session Admin
+
+      Administrative tool for managing OpenClaw sessions.
+
+      ## Security Notice
+
+      CVE-2026-34512 affects OpenClaw versions prior to 2026.3.25. The
+      /sessions/:sessionKey/kill endpoint has improper access control that
+      allows unauthorized users to terminate active sessions belonging to
+      other users without proper authorization checks.
+    test_expect: fires
+  - id: PSV-031
+    category: platform_security
+    severity: high
+    confidence: 0.9
+    title: OpenClaw privilege escalation via chat.send to allowlist persistence (CVE-2026-35621, < 2026.3.24)
+    pattern: (?i)(?:CVE-2026-35621|openclaw[^\n]{0,80}(?:chat\.send[^\n]{0,40}allowlist|allowlist[_\s-]?persist|2026\.3\.(?:1[0-9]|2[0-3])\b[^\n]{0,40}(?:priv|escal|allowlist|chat\.send))|chat\.send[^\n]{0,80}(?:allowlist|persist|priv|escal|openclaw))
+    mitigation: 'CVE-2026-35621 (CVSS 7.1, CWE-862) is a privilege escalation vulnerability in OpenClaw prior to version 2026.3.24. Attackers can use the chat.send endpoint to persist entries in the allowlist, achieving persistent privilege escalation. Upgrade OpenClaw to version 2026.3.24 or later.'
+    metadata:
+      version: 1.0.0
+      status: active
+      techniques:
+        - id: PSV-031
+          name: Platform security vulnerability
+      tags:
+        - platform_security
+        - psv
+        - openclaw
+        - privilege_escalation
+        - allowlist_bypass
+      applies_to:
+        contexts:
+          - source
+          - workflow
+      lifecycle:
+        introduced: '2026-04-19'
+        last_modified: '2026-04-19'
+      quality:
+        precision_estimate: 0.9
+        benchmark_set: core-static-v1
+      references:
+        - https://github.com/jgamblin/OpenClawCVEs
+        - https://nvd.nist.gov/vuln/detail/CVE-2026-35621
+      author: skillscan
+      created: '2026-04-19'
+      last_modified: '2026-04-19'
+      updated: '2026-04-19'
+    test_input: |
+      ---
+      name: openclaw-chat-integration
+      description: OpenClaw chat and messaging integration
+      ---
+
+      # OpenClaw Chat Integration
+
+      This skill provides chat messaging capabilities for OpenClaw.
+
+      ## Security Advisory
+
+      CVE-2026-35621 affects OpenClaw versions prior to 2026.3.24. A privilege
+      escalation vulnerability exists where the chat.send endpoint can be abused
+      to persist entries in the allowlist. This allows attackers to achieve
+      persistent privilege escalation by adding unauthorized entries to the
+      command allowlist through the chat interface.
     test_expect: fires
 capability_patterns:
   shell_execution: \b(subprocess|os\.system|bash|powershell)\b

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2560,3 +2560,88 @@ def test_psv025_open_vsx_scan_bypass() -> None:
     assert rule.pattern.search("vsx scan job fail open connection pool exhaust") is not None
     # Negative: benign open vsx usage
     assert rule.pattern.search("install extension from open vsx registry") is None
+
+
+def test_psv026_mcp_neo4j_sse_rce() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-026"]
+    assert rules, "PSV-026 not found"
+    rule = rules[0]
+    # CVE anchor
+    assert rule.pattern.search("CVE-2025-56406 mcp-neo4j vulnerability") is not None
+    # Pattern anchors
+    assert rule.pattern.search("mcp-neo4j command injection RCE vulnerability") is not None
+    assert rule.pattern.search("mcp neo4j SSE service unauthenticated endpoint exploit") is not None
+    assert rule.pattern.search("neo4j mcp SSE inject RCE") is not None
+    # Negative: benign neo4j usage
+    assert rule.pattern.search("neo4j graph database tutorial") is None
+
+
+def test_psv027_aap_mcp_log_injection() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-027"]
+    assert rules, "PSV-027 not found"
+    rule = rules[0]
+    # CVE anchor
+    assert rule.pattern.search("CVE-2026-6494 aap mcp server vulnerability") is not None
+    # Pattern anchors
+    assert rule.pattern.search("aap-mcp-server log injection toolsetroute") is not None
+    assert rule.pattern.search("toolsetroute inject ANSI escape sequence") is not None
+    # Negative: benign AAP usage
+    assert rule.pattern.search("ansible automation platform deployment guide") is None
+
+
+def test_psv028_openclaw_pair_approve_scope() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-028"]
+    assert rules, "PSV-028 not found"
+    rule = rules[0]
+    # CVE anchor
+    assert rule.pattern.search("CVE-2026-35639 openclaw privilege escalation") is not None
+    # Pattern anchors
+    assert rule.pattern.search("openclaw device.pair.approve scope validation bypass") is not None
+    assert rule.pattern.search("device.pair.approve scope bypass escalation") is not None
+    # Negative: benign openclaw usage
+    assert rule.pattern.search("openclaw getting started tutorial") is None
+
+
+def test_psv029_openclaw_shared_auth_reconnect() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-029"]
+    assert rules, "PSV-029 not found"
+    rule = rules[0]
+    # CVE anchor
+    assert rule.pattern.search("CVE-2026-35625 openclaw shared auth reconnect") is not None
+    # Pattern anchors
+    assert rule.pattern.search("openclaw shared-auth reconnect privilege escalation") is not None
+    assert rule.pattern.search("shared-auth reconnect silent escalation openclaw") is not None
+    # Negative: benign auth usage
+    assert rule.pattern.search("oauth2 shared authentication flow") is None
+
+
+def test_psv030_openclaw_session_kill_access_control() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-030"]
+    assert rules, "PSV-030 not found"
+    rule = rules[0]
+    # CVE anchor
+    assert rule.pattern.search("CVE-2026-34512 openclaw session kill vulnerability") is not None
+    # Pattern anchors
+    assert rule.pattern.search("openclaw /sessions/:sessionKey/kill access control") is not None
+    assert rule.pattern.search("/sessions/:sessionKey/kill unauthorized openclaw") is not None
+    # Negative: benign session management
+    assert rule.pattern.search("session management best practices") is None
+
+
+def test_psv031_openclaw_chat_send_allowlist() -> None:
+    compiled = load_compiled_builtin_rulepack()
+    rules = [r for r in compiled.static_rules if r.id == "PSV-031"]
+    assert rules, "PSV-031 not found"
+    rule = rules[0]
+    # CVE anchor
+    assert rule.pattern.search("CVE-2026-35621 openclaw chat.send allowlist") is not None
+    # Pattern anchors
+    assert rule.pattern.search("openclaw chat.send allowlist persistence privilege escalation") is not None
+    assert rule.pattern.search("chat.send allowlist persist escalation openclaw") is not None
+    # Negative: benign chat usage
+    assert rule.pattern.search("slack chat api send message") is None


### PR DESCRIPTION
## Pattern Update 2026-04-19

### New Rules (6)
- **PSV-026**: mcp-neo4j SSE command injection RCE (CVE-2025-56406)
- **PSV-027**: AAP MCP Server log injection (CVE-2026-6494)
- **PSV-028**: OpenClaw device.pair.approve scope bypass (CVE-2026-35639)
- **PSV-029**: OpenClaw shared-auth reconnect priv esc (CVE-2026-35625)
- **PSV-030**: OpenClaw session kill access control (CVE-2026-34512)
- **PSV-031**: OpenClaw chat.send allowlist persistence (CVE-2026-35621)

### Other Changes
- Vuln DB: 6 new entries
- PATTERN_UPDATES.md: source-backed rationale
- docs/EXAMPLES.md: regenerated
- tests/test_rules.py: 6 new test functions (all 132 tests pass)
- validate_pattern_update.py: all checks pass