### PR TITLE
chore(cron): disable sync-bundled-rules schedule; daily agent owns sync now

### DIFF
--- a/.github/workflows/sync-bundled-rules.yml
+++ b/.github/workflows/sync-bundled-rules.yml
@@ -1,18 +1,21 @@
 name: Sync Bundled Rules
 
-# Pulls the canonical rule and intel files from skillscan-rules into the
-# bundled snapshot shipped inside this Python package. Intel changes daily
-# (refreshed in skillscan-rules by refresh-intel.yml); rules change less
-# often. A single twice-daily run handles both — when nothing changed,
-# peter-evans/create-pull-request opens no PR.
+# MANUAL FALLBACK ONLY — the daily 12:00 UTC pattern-update agent now syncs
+# the bundled rules+intel snapshot as part of its normal flow, eliminating
+# this workflow's previous role as a scheduled cron.
 #
-# Auto-merges the resulting PR once the 4 required status checks pass, so
-# data refresh stays hands-free.
+# Why: PRs created by GITHUB_TOKEN do not trigger workflow runs (a security
+# feature against CI loops), so this workflow's auto-merge loop was
+# structurally broken — the resulting PR's required-status-check CI never
+# fired and the PR sat open forever. The daily agent runs as a real user,
+# so its PRs trigger CI normally.
+#
+# Kept as `workflow_dispatch` only so an operator can manually re-sync if
+# the daily agent missed a run. If you find yourself reaching for this
+# regularly, the daily agent is broken — investigate that, don't paper
+# over it here.
 
 on:
-  schedule:
-    - cron: "0 7 * * *"   # 07:00 UTC — ~1h after the canonical refresh at 06:00
-    - cron: "0 19 * * *"  # 19:00 UTC — ~1h after the canonical refresh at 18:00
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary

Removes the `0 7 * * *` and `0 19 * * *` cron triggers on `sync-bundled-rules.yml`. Keeps `workflow_dispatch` as a manual fallback. The 12:00 UTC pattern-update agent will now do the bundled-rules sync as part of its daily flow.

## Why

Tonight I discovered the cron's auto-merge loop is **structurally broken**: PRs created by `GITHUB_TOKEN` don't trigger workflow runs (GitHub security feature against CI loops). The four required status checks never fired on the auto-opened sync PR, so auto-merge waited forever, and the next cron run force-pushed the same content with no progress.

PR #210 (the test-dispatched sync PR from earlier tonight) only got CI to fire because I close+reopened it from my user account — exactly the workaround the cron can't perform on itself.

## Three fix options considered

1. **PAT** — clean but requires user to create + store a token
2. **`workflow_run` workaround** — complex, more moving parts
3. **Fold sync into daily agent** ← *picked*

## Trade-offs

- Bundled snapshot updates daily (12:00 UTC) instead of twice daily (07/19 UTC). Canonical intel still refreshes twice daily on the rules side; the bundled snapshot is a release-time artifact and daily freshness is fine.
- Eliminates one whole broken layer.
- Daily agent's PRs come from a real user → CI fires naturally.

## Companion changes (separate commits)

- `skillscan-private/skills/skillscan-pattern-update/SKILL.md` gets a new "Step 7" describing the bundled-snapshot sync
- The 12:00 UTC scheduled remote agent's prompt gets updated to perform the sync
- The 22:00 UTC daily verification routine drops its expectation of `sync-bundled-rules.yml` cron runs and instead checks for the daily agent's bundled-snapshot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)