### PR TITLE
ci: bump test job timeout 30 → 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Bumped from 30 → 45 on 2026-05-20. Recent successful test (3.12) runs
+    # have been finishing in 24-29 min (very close to the prior 30-min
+    # ceiling), and sync-bundled-snapshot PRs from May 17 onward all hit the
+    # ceiling and got cancelled. Root cause is test-suite growth; 50%
+    # headroom buys time to land the backlog while a permanent fix (slow-
+    # test markers + a split fast/slow lane) is designed.
+    timeout-minutes: 45
     strategy:
       matrix:
         python-version: ['3.12', '3.13']


### PR DESCRIPTION
## Summary

Three sync-bundled-snapshot PRs (#238/#239/#240) on May 17-19 all hit the 30-min test (3.12) ceiling and were cancelled. Recent successful runs finished in 24-29 min, so the test suite grew past 30 min around May 17.

This is the second timeout bump (April 26 was 20 → 30). The pattern is clear: tests grow, timeout chases. Permanent fix is `@pytest.mark.slow` + split lanes — deferred. 50% headroom unblocks today's backlog.

Once this merges, will trigger reruns on #238/#239/#240 (and consider closing the older two since #240 supersedes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)