### PR TITLE
ci: parallelize tests with pytest-xdist (Option B — CI growth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,18 @@ jobs:
           mypy src
       - name: Tests with coverage
         if: steps.changes.outputs.code == 'true' && matrix.python-version == '3.12'
+        # -n auto: spawn one worker per CPU core (2 on ubuntu-latest, sometimes 4)
+        # --dist=loadfile: keep all tests from the same file in the same worker
+        #   (safer than the default `load` distribution against any per-file
+        #   fixture ordering hazards; conftest's lru_cache clear is per-test
+        #   so already safe across workers, but loadfile costs almost nothing
+        #   and removes a class of "passes serially / fails in parallel" bugs)
         run: |
-          pytest -q --cov=skillscan --cov-report=xml --cov-report=term
+          pytest -q -n auto --dist=loadfile --cov=skillscan --cov-report=xml --cov-report=term
       - name: Tests
         if: steps.changes.outputs.code == 'true' && matrix.python-version != '3.12'
         run: |
-          pytest -q
+          pytest -q -n auto --dist=loadfile
       - name: Upload coverage to Codecov
         if: steps.changes.outputs.code == 'true' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 dev = [
   "pytest>=8.2.0",
   "pytest-cov>=5.0.0",
+  "pytest-xdist>=3.6.0",
   "ruff>=0.4.4",
   "mypy>=1.10.0"
 ]


### PR DESCRIPTION
## Summary

Adds \`pytest-xdist\` and runs the remaining slow test job (code-touching PRs after Option A's data fast lane) with \`-n auto --dist=loadfile\`. Expected ~50% speedup on the 2-core ubuntu-latest runner.

## Expected impact

- **test (3.12) with coverage**: 30 min → ~15-20 min
- **test (3.13) without coverage**: 16 min → ~8-10 min

This PR will itself be the first measurement — the timing on this PR's own \`test (3.12)\` step is the data point.

## Why \`--dist=loadfile\` vs default \`load\`

Default \`load\` distributes individual tests across workers. \`loadfile\` keeps all tests from the same file in the same worker. Slightly less optimal load balancing, but eliminates any "passes serially / fails in parallel" hazards from per-file fixture ordering. The autouse \`_clear_rulepack_cache\` in \`tests/conftest.py\` is already per-test so it's safe across workers either way; \`loadfile\` costs nothing here and adds robustness.

\`pytest-cov\` supports xdist out of the box — coverage data from each worker is merged automatically; no extra config needed.

## Context

This is **Option B** from the 2026-05-20 CI growth plan. **Option A** (data-only fast lane, #244) merged ~06:27 UTC. **Option F** (\`test_rules.py\` → YAML round-trip migration) deferred to a dedicated session per user direction.

## Combined effect of A + B

| PR type | Before tonight | After A | After A + B |
|---|---|---|---|
| Sync (data-only) | ~30 min | ~1.5 min | ~1.5 min |
| Code-touching | ~30 min | ~30 min | **~15 min** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)