### PR TITLE
ci: OIDC trusted publishing for PyPI (drop PYPI token)

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -101,6 +101,8 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/skillscan-security
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
     steps:
       - name: Download package artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
Make the PyPI publish job use OIDC **trusted publishing** explicitly.

## Changes
- Add job-level \`permissions: id-token: write\` to the \`publish\` job.

## Notes
This workflow already publishes via \`pypa/gh-action-pypi-publish@release/v1\` with **no** \`password:\` input, so there was no long-lived PyPI token to remove. The action auto-uses OIDC when \`id-token: write\` is present. A top-level \`id-token: write\` permission existed, but this PR adds it explicitly at the publishing-job level (the standard, least-surprise pattern). No Docker/\`release-docker.yml\` changes.

## ⚠️ Action required before next release
A **PyPI Trusted Publisher** must be configured for package \`skillscan-security\` (repo \`kurtpayne/skillscan-security\`, workflow filename \`release-pypi.yml\`, environment \`pypi\`) **before** the next \`v*\` release tag, or the publish will fail.

Do NOT merge until the PyPI trusted-publisher config is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)